### PR TITLE
fix(ts): declare node-pty as optionalDependency to unblock tsc check

### DIFF
--- a/agentchatbus-ts/package-lock.json
+++ b/agentchatbus-ts/package-lock.json
@@ -14,8 +14,8 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/headless": "^6.0.0",
         "@xterm/xterm": "^6.0.0",
+        "cross-spawn": "^7.0.6",
         "fastify": "^5.2.1",
-        "node-pty": "^1.1.0",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -34,6 +34,9 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "optionalDependencies": {
+        "node-pty": "^1.1.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2681,7 +2684,8 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-pty": {
       "version": "1.1.0",
@@ -2689,6 +2693,7 @@
       "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "node-addon-api": "^7.1.0"
       }

--- a/agentchatbus-ts/package.json
+++ b/agentchatbus-ts/package.json
@@ -39,5 +39,8 @@
     "tsx": "^4.19.2",
     "typescript": "^5.8.2",
     "vitest": "^3.1.1"
+  },
+  "optionalDependencies": {
+    "node-pty": "^1.1.0"
   }
 }


### PR DESCRIPTION
## Summary

The lockfile (`agentchatbus-ts/package-lock.json`) declares `node-pty: ^1.1.0` but `agentchatbus-ts/package.json` does not list it under any dependency block. After a clean install on a platform without C++ build tools (default Windows, minimal Linux images), `node-pty` ends up missing from `node_modules` and `npm run check` fails with **6 TS2307 errors** on `claudeInteractiveAdapter.ts` and `cursorInteractiveAdapter.ts` because their type-only imports of `node-pty` are evaluated at type-check time.

This PR declares `node-pty: ^1.1.0` under `optionalDependencies` so:

- `npm install` fetches `node-pty` when build tools are available.
- `npm install` proceeds with a warning when build tools are missing, instead of failing the install.
- `tsc -p tsconfig.json --noEmit` resolves the types and stays green everywhere.

The runtime guards (`dynamic import(node-pty).catch(...)`) already in place across the three interactive adapters (`claudeInteractiveAdapter.ts`, `cursorInteractiveAdapter.ts`, `workers/interactivePtyWorker.mjs`) keep their clean fallback error message, so no source code changes are needed.

## Reproduction (clean state)

```bash
cd agentchatbus-ts
rm -rf node_modules/node-pty
npm run check
```

Yields 6 errors:

```
src/core/services/adapters/claudeInteractiveAdapter.ts(14,36): error TS2307: Cannot find module 'node-pty' or its corresponding type declarations.
src/core/services/adapters/claudeInteractiveAdapter.ts(15,27): error TS2307: ...
src/core/services/adapters/claudeInteractiveAdapter.ts(25,35): error TS2307: ...
src/core/services/adapters/cursorInteractiveAdapter.ts(17,36): error TS2307: ...
src/core/services/adapters/cursorInteractiveAdapter.ts(18,27): error TS2307: ...
src/core/services/adapters/cursorInteractiveAdapter.ts(59,35): error TS2307: ...
```

## Root cause

The runtime imports use `dynamic import(node-pty).catch(...)` and degrade gracefully, but the **type imports** (`type NodePtyModule = typeof import(node-pty)` and `type PtyInstance = import(node-pty).IPty`) are resolved by `tsc` at compile time and require the module declaration to be reachable.

## Fix

Add the following to `agentchatbus-ts/package.json`:

```json
optionalDependencies: {
  node-pty: ^1.1.0
}
```

The lockfile naturally re-syncs to mark `node-pty` and its native dep `node-addon-api` as `optional: true`.

## Verification

- `npm install` -> clean (1 transitive dep moved to optional, lock aligned with manifest)
- `npm run check` -> green
- `npm run build` -> green (1.9MB bundle, 31s)
- `npm test` -> 670 passed / 28 failed; **all 28 failures are pre-existing on `upstream/main` and unrelated to PTY adapters**. Verified by stashing this fix and rerunning the same failing files (e.g. `test_cursor_direct_adapter.test.ts > extracts assistant text from ACP session/update message chunks` fails identically on clean upstream/main with `'Hello fromCursor ACP'` vs `'Hello from Cursor ACP'`).

## Files changed

- `agentchatbus-ts/package.json` (+3)
- `agentchatbus-ts/package-lock.json` (+7 / -2, all auto-resync)

No source code changes.