### PR TITLE
fix(web-ui): sync thread-restart UI to agentchatbus-ts bundle

### DIFF
--- a/agentchatbus-ts/web-ui/js/components/acb-modal-shell.js
+++ b/agentchatbus-ts/web-ui/js/components/acb-modal-shell.js
@@ -399,6 +399,46 @@
           </div>
         </div>
 
+        <div id="thread-restart-modal-overlay" onclick="closeRestartThreadModal(event)" class="meeting-modal-hidden" style="position:fixed;inset:0;background:rgba(0,0,0,.72);align-items:center;justify-content:center;z-index:100;animation:fade-in .15s ease;">
+          <div id="thread-restart-modal" class="settings-modal-container" style="width:520px; height:auto; max-height:85vh;" onclick="event.stopPropagation()">
+            <div class="settings-modal-header">
+              <h3>Restart Thread</h3>
+              <button class="settings-close-btn" onclick="closeRestartThreadModal()" title="Close">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+              </button>
+            </div>
+
+            <div class="settings-content" style="background:var(--bg-base); padding:24px; display:flex; flex-direction:column; gap:18px;">
+              <div id="thread-restart-modal-context" class="settings-field-description">
+                Restarting creates a brand new thread with new agent identities and tokens, then removes the old thread's discussion history and records after the restart succeeds.
+              </div>
+
+              <div class="settings-field" style="margin-bottom:0;">
+                <label for="thread-restart-modal-workspace">Workspace</label>
+                <input id="thread-restart-modal-workspace" type="text" readonly />
+                <div class="settings-field-description">
+                  Workspace cleanup is only allowed when this path is the git repository root. The repo directory itself is preserved, and the <code>.git</code> entry is kept.
+                </div>
+              </div>
+
+              <label class="meeting-modal-radio" style="cursor:pointer; align-items:flex-start;">
+                <input id="thread-restart-clear-workspace" type="checkbox" />
+                <div>
+                  <strong>Clear workspace contents</strong>
+                  <span>Delete everything inside the repo root except <code>.git</code>. Disabled by default and blocked for non-git folders or unsafe paths.</span>
+                </div>
+              </label>
+
+              <div id="thread-restart-modal-error" class="settings-field-description settings-field-description--error meeting-modal-hidden"></div>
+            </div>
+
+            <div class="settings-modal-footer">
+              <button id="thread-restart-cancel-btn" class="btn-secondary" onclick="closeRestartThreadModal()">Cancel</button>
+              <button id="thread-restart-submit-btn" class="btn-destructive" onclick="submitRestartThreadModal()">Restart Thread</button>
+            </div>
+          </div>
+        </div>
+
         <div id="settings-modal-overlay" onclick="closeSettingsModal(event)"
           style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.7);align-items:center;justify-content:center;z-index:100;animation:fade-in .15s ease;">
           <div id="settings-modal" class="settings-modal-container" onclick="event.stopPropagation()">

--- a/agentchatbus-ts/web-ui/js/components/acb-thread-header.js
+++ b/agentchatbus-ts/web-ui/js/components/acb-thread-header.js
@@ -29,6 +29,13 @@
               </svg>
               <span>Add Agent</span>
             </button>
+            <button id="thread-restart-btn" class="thread-header-cta" type="button" title="Restart this thread" aria-label="Restart this thread" onclick="window.openRestartThreadModal && window.openRestartThreadModal()">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M23 4v6h-6"/>
+                <path d="M20.49 15A9 9 0 1 1 23 10"/>
+              </svg>
+              <span>Restart Thread</span>
+            </button>
             <button id="export-thread-btn" type="button" title="Export as Markdown" aria-label="Export thread as Markdown" onclick="exportFromHeader()">
               <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
                 <path d="M8 1v9M4.5 6.5 8 10l3.5-3.5M2 11v2.5A1.5 1.5 0 0 0 3.5 15h9A1.5 1.5 0 0 0 14 13.5V11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>

--- a/agentchatbus-ts/web-ui/js/shared-modals.js
+++ b/agentchatbus-ts/web-ui/js/shared-modals.js
@@ -19,6 +19,11 @@
       visibility: "style",
       styleVisibleValue: "flex",
     },
+    "thread-restart": {
+      overlayId: "thread-restart-modal-overlay",
+      visibility: "style",
+      styleVisibleValue: "flex",
+    },
   };
 
   /**
@@ -2550,6 +2555,150 @@
     }
   }
 
+  function setRestartThreadError(message) {
+    const errorEl = document.getElementById("thread-restart-modal-error");
+    if (!errorEl) {
+      return;
+    }
+    const text = String(message || "").trim();
+    errorEl.textContent = text;
+    errorEl.classList.toggle("meeting-modal-hidden", !text);
+  }
+
+  function setRestartThreadSubmittingState(isSubmitting) {
+    const submitBtn = document.getElementById("thread-restart-submit-btn");
+    const cancelBtn = document.getElementById("thread-restart-cancel-btn");
+    const checkbox = document.getElementById("thread-restart-clear-workspace");
+    if (submitBtn) {
+      submitBtn.disabled = Boolean(isSubmitting);
+      submitBtn.textContent = isSubmitting ? "Restarting..." : "Restart Thread";
+    }
+    if (cancelBtn) {
+      cancelBtn.disabled = Boolean(isSubmitting);
+    }
+    if (checkbox) {
+      checkbox.disabled = Boolean(isSubmitting);
+    }
+  }
+
+  async function loadCurrentThreadSummary(api, threadId) {
+    if (!api || !threadId) {
+      return null;
+    }
+    const response = await api("/api/threads?include_archived=1");
+    const threads = Array.isArray(response?.threads) ? response.threads : [];
+    return threads.find((thread) => String(thread?.id || "").trim() === String(threadId || "").trim()) || null;
+  }
+
+  async function openRestartThreadModal(api) {
+    const threadId = window.currentThreadId;
+    if (!threadId) {
+      return;
+    }
+    setRestartThreadError("");
+    setRestartThreadSubmittingState(false);
+
+    const checkbox = document.getElementById("thread-restart-clear-workspace");
+    const workspaceInput = document.getElementById("thread-restart-modal-workspace");
+    const contextEl = document.getElementById("thread-restart-modal-context");
+    const threadTitle = document.getElementById("thread-title")?.textContent?.trim() || "current thread";
+    const threadSummary = await loadCurrentThreadSummary(api, threadId);
+    const workspace = String(threadSummary?.workspace || "").trim();
+
+    if (checkbox) {
+      checkbox.checked = false;
+    }
+    if (workspaceInput) {
+      workspaceInput.value = workspace || "(No workspace configured)";
+    }
+    if (contextEl) {
+      contextEl.textContent = `Restart "${threadTitle}" as a brand new thread. Existing discussion records are removed only after the replacement thread and agent launches succeed.`;
+    }
+
+    setModalVisible("thread-restart", true);
+  }
+
+  function closeRestartThreadModal(e) {
+    if (!e || isOverlayClick(e, "thread-restart")) {
+      setRestartThreadError("");
+      setRestartThreadSubmittingState(false);
+      setModalVisible("thread-restart", false);
+    }
+  }
+
+  async function submitRestartThreadModal(deps) {
+    const { api, refreshThreads, selectThread } = deps;
+    const threadId = window.currentThreadId;
+    if (!threadId) {
+      return;
+    }
+
+    const uiAgent = window.AcbUiAgent ? await window.AcbUiAgent.ensureUiAgent() : null;
+    if (!uiAgent) {
+      setRestartThreadError("Could not obtain the Browser User token needed to restart this thread.");
+      return;
+    }
+
+    const clearWorkspace = document.getElementById("thread-restart-clear-workspace")?.checked === true;
+    const wasPinned = !!window.AcbThreads?.isThreadPinned?.(threadId);
+    setRestartThreadError("");
+    setRestartThreadSubmittingState(true);
+
+    try {
+      const result = await api(`/api/threads/${threadId}/restart`, {
+        method: "POST",
+        headers: {
+          "X-Agent-Token": uiAgent.token,
+        },
+        body: JSON.stringify({
+          requested_by_agent_id: uiAgent.agent_id,
+          clear_workspace: clearWorkspace,
+        }),
+      });
+
+      if (!result?.ok || !result?.new_thread?.id) {
+        setRestartThreadError(result?.detail || "Failed to restart the thread.");
+        setRestartThreadSubmittingState(false);
+        return;
+      }
+
+      const nextThread = result.new_thread;
+      if (wasPinned && window.AcbThreads?.setThreadPinned) {
+        window.AcbThreads.setThreadPinned(threadId, false);
+        window.AcbThreads.setThreadPinned(nextThread.id, true);
+      }
+
+      closeRestartThreadModal();
+
+      if (typeof refreshThreads === "function") {
+        await refreshThreads();
+      }
+
+      const syncContext =
+        typeof nextThread.current_seq === "number" && nextThread.reply_token
+          ? {
+              current_seq: nextThread.current_seq,
+              reply_token: nextThread.reply_token,
+              reply_window: nextThread.reply_window || null,
+            }
+          : null;
+
+      if (typeof selectThread === "function") {
+        await selectThread(nextThread.id, nextThread.topic, nextThread.status, syncContext);
+      }
+
+      if (window.AcbChat && typeof window.AcbChat.refreshThreadAdmin === "function") {
+        await window.AcbChat.refreshThreadAdmin(nextThread.id, api);
+      }
+      if (window.AcbCliSessions && typeof window.AcbCliSessions.refreshThread === "function") {
+        await window.AcbCliSessions.refreshThread(nextThread.id, api);
+      }
+    } catch (error) {
+      setRestartThreadError(error instanceof Error ? error.message : String(error));
+      setRestartThreadSubmittingState(false);
+    }
+  }
+
   async function submitAddAgentModal(deps) {
     const { api, refreshAgents } = deps;
     const threadId = window.currentThreadId;
@@ -3028,6 +3177,9 @@
     openAddAgentModal,
     closeAddAgentModal,
     submitAddAgentModal,
+    openRestartThreadModal,
+    closeRestartThreadModal,
+    submitRestartThreadModal,
     switchAddAgentTab,
     openSettingsModal,
     closeSettingsModal,
@@ -3055,6 +3207,19 @@
     return openAddAgentModal(api);
   };
   window.closeAddAgentModal = closeAddAgentModal;
+  window.openRestartThreadModal = function() {
+    const api = _resolveApi();
+    return openRestartThreadModal(api);
+  };
+  window.closeRestartThreadModal = closeRestartThreadModal;
+  window.submitRestartThreadModal = function() {
+    const api = _resolveApi();
+    return submitRestartThreadModal({
+      api,
+      refreshThreads: typeof window.refreshThreads === "function" ? window.refreshThreads : null,
+      selectThread: typeof window.selectThread === "function" ? window.selectThread : null,
+    });
+  };
   window.submitAddAgentModal = function() {
     const api = _resolveApi();
     return submitAddAgentModal({

--- a/vscode-agentchatbus/resources/web-ui/js/components/acb-modal-shell.js
+++ b/vscode-agentchatbus/resources/web-ui/js/components/acb-modal-shell.js
@@ -147,7 +147,29 @@
                           </select>
                           <div id="modal-template-desc" class="settings-field-description" style="margin-top:4px; min-height:1.4em;"></div>
                         </div>
+                        <div class="settings-field thread-workspace-field">
+                          <label for="modal-workspace">Working Directory</label>
+                          <div class="thread-workspace-row">
+                            <input id="modal-workspace" type="text" placeholder="Working directory for this thread" />
+                            <button
+                              id="modal-workspace-picker"
+                              class="btn-secondary thread-workspace-row__button"
+                              type="button"
+                              onclick="window.AcbModals && window.AcbModals.pickThreadWorkspace()"
+                            >
+                              Choose Folder
+                            </button>
+                          </div>
+                          <div
+                            id="modal-workspace-desc"
+                            class="settings-field-description"
+                            data-default-text="Default CLI workspace for this thread. All later agent launches in this thread inherit it unless a session overrides the path."
+                          >
+                            Default CLI workspace for this thread. All later agent launches in this thread inherit it unless a session overrides the path.
+                          </div>
+                        </div>
                       </div>
+                      <div id="thread-create-error" class="settings-field-description settings-field-description--error meeting-modal-hidden"></div>
                     </div>
 
                     <div id="thread-agent-config" class="meeting-modal-section meeting-modal-section--compact">
@@ -373,6 +395,46 @@
             <div class="settings-modal-footer">
               <button class="btn-secondary" onclick="closeAddAgentModal()">Cancel</button>
               <button id="btn-add-agent-submit" class="btn-primary" onclick="submitAddAgentModal()">Add Agent</button>
+            </div>
+          </div>
+        </div>
+
+        <div id="thread-restart-modal-overlay" onclick="closeRestartThreadModal(event)" class="meeting-modal-hidden" style="position:fixed;inset:0;background:rgba(0,0,0,.72);align-items:center;justify-content:center;z-index:100;animation:fade-in .15s ease;">
+          <div id="thread-restart-modal" class="settings-modal-container" style="width:520px; height:auto; max-height:85vh;" onclick="event.stopPropagation()">
+            <div class="settings-modal-header">
+              <h3>Restart Thread</h3>
+              <button class="settings-close-btn" onclick="closeRestartThreadModal()" title="Close">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+              </button>
+            </div>
+
+            <div class="settings-content" style="background:var(--bg-base); padding:24px; display:flex; flex-direction:column; gap:18px;">
+              <div id="thread-restart-modal-context" class="settings-field-description">
+                Restarting creates a brand new thread with new agent identities and tokens, then removes the old thread's discussion history and records after the restart succeeds.
+              </div>
+
+              <div class="settings-field" style="margin-bottom:0;">
+                <label for="thread-restart-modal-workspace">Workspace</label>
+                <input id="thread-restart-modal-workspace" type="text" readonly />
+                <div class="settings-field-description">
+                  Workspace cleanup is only allowed when this path is the git repository root. The repo directory itself is preserved, and the <code>.git</code> entry is kept.
+                </div>
+              </div>
+
+              <label class="meeting-modal-radio" style="cursor:pointer; align-items:flex-start;">
+                <input id="thread-restart-clear-workspace" type="checkbox" />
+                <div>
+                  <strong>Clear workspace contents</strong>
+                  <span>Delete everything inside the repo root except <code>.git</code>. Disabled by default and blocked for non-git folders or unsafe paths.</span>
+                </div>
+              </label>
+
+              <div id="thread-restart-modal-error" class="settings-field-description settings-field-description--error meeting-modal-hidden"></div>
+            </div>
+
+            <div class="settings-modal-footer">
+              <button id="thread-restart-cancel-btn" class="btn-secondary" onclick="closeRestartThreadModal()">Cancel</button>
+              <button id="thread-restart-submit-btn" class="btn-destructive" onclick="submitRestartThreadModal()">Restart Thread</button>
             </div>
           </div>
         </div>

--- a/vscode-agentchatbus/resources/web-ui/js/components/acb-thread-header.js
+++ b/vscode-agentchatbus/resources/web-ui/js/components/acb-thread-header.js
@@ -29,6 +29,13 @@
               </svg>
               <span>Add Agent</span>
             </button>
+            <button id="thread-restart-btn" class="thread-header-cta" type="button" title="Restart this thread" aria-label="Restart this thread" onclick="window.openRestartThreadModal && window.openRestartThreadModal()">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M23 4v6h-6"/>
+                <path d="M20.49 15A9 9 0 1 1 23 10"/>
+              </svg>
+              <span>Restart Thread</span>
+            </button>
             <button id="export-thread-btn" type="button" title="Export as Markdown" aria-label="Export thread as Markdown" onclick="exportFromHeader()">
               <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
                 <path d="M8 1v9M4.5 6.5 8 10l3.5-3.5M2 11v2.5A1.5 1.5 0 0 0 3.5 15h9A1.5 1.5 0 0 0 14 13.5V11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>

--- a/vscode-agentchatbus/resources/web-ui/js/shared-modals.js
+++ b/vscode-agentchatbus/resources/web-ui/js/shared-modals.js
@@ -19,6 +19,11 @@
       visibility: "style",
       styleVisibleValue: "flex",
     },
+    "thread-restart": {
+      overlayId: "thread-restart-modal-overlay",
+      visibility: "style",
+      styleVisibleValue: "flex",
+    },
   };
 
   /**
@@ -1142,6 +1147,183 @@
     return Math.round(seconds * 1000);
   }
 
+  function getThreadWorkspaceInput() {
+    const input = document.getElementById("modal-workspace");
+    return input instanceof HTMLInputElement ? input : null;
+  }
+
+  function getThreadWorkspaceDescriptionEl() {
+    const el = document.getElementById("modal-workspace-desc");
+    return el instanceof HTMLElement ? el : null;
+  }
+
+  function getThreadCreateErrorEl() {
+    const el = document.getElementById("thread-create-error");
+    return el instanceof HTMLElement ? el : null;
+  }
+
+  function clearThreadCreateError() {
+    const errorEl = getThreadCreateErrorEl();
+    if (!errorEl) {
+      return;
+    }
+    errorEl.textContent = "";
+    errorEl.classList.add("meeting-modal-hidden");
+  }
+
+  function setThreadCreateError(message) {
+    const errorEl = getThreadCreateErrorEl();
+    if (!errorEl) {
+      return;
+    }
+    errorEl.textContent = String(message || "").trim();
+    errorEl.classList.toggle("meeting-modal-hidden", !errorEl.textContent);
+  }
+
+  function setThreadWorkspaceDescription(message, options = {}) {
+    const descEl = getThreadWorkspaceDescriptionEl();
+    if (!descEl) {
+      return;
+    }
+    const defaultText = String(descEl.dataset.defaultText || "").trim();
+    const nextText = String(message || "").trim() || defaultText;
+    descEl.textContent = nextText;
+    descEl.classList.toggle("settings-field-description--error", options.error === true);
+  }
+
+  function formatThreadWorkspaceSource(source) {
+    switch (String(source || "").trim()) {
+      case "configured":
+        return "configured default";
+      case "process_cwd":
+        return "service working directory";
+      case "user_home":
+        return "user home fallback";
+      default:
+        return "service default";
+    }
+  }
+
+  async function loadThreadWorkspaceDefaults(api, options = {}) {
+    const input = getThreadWorkspaceInput();
+    if (!input || (!options.force && String(input.value || "").trim())) {
+      return;
+    }
+    setThreadWorkspaceDescription("");
+    if (!api) {
+      syncThreadWorkspacePickerState();
+      return;
+    }
+    const defaults = await api("/api/cli-defaults");
+    const workspace = String(defaults?.workspace || "").trim();
+    if (workspace) {
+      input.value = workspace;
+    }
+    const sourceLabel = formatThreadWorkspaceSource(defaults?.source);
+    setThreadWorkspaceDescription(
+      workspace
+        ? `Default from ${sourceLabel}: ${workspace}`
+        : "Default CLI workspace for this thread. All later agent launches in this thread inherit it unless a session overrides the path.",
+    );
+    syncThreadWorkspacePickerState();
+  }
+
+  function syncThreadWorkspacePickerState() {
+    const button = document.getElementById("modal-workspace-picker");
+    if (!(button instanceof HTMLButtonElement)) {
+      return;
+    }
+    button.disabled = false;
+    button.title = "Choose a folder for this thread. On Windows, the local service opens a native directory dialog.";
+  }
+
+  function setThreadWorkspacePickerBusy(busy, label) {
+    const button = document.getElementById("modal-workspace-picker");
+    if (!(button instanceof HTMLButtonElement)) {
+      return;
+    }
+    const nextLabel = String(label || "").trim() || (busy ? "Opening..." : "Choose Folder");
+    button.disabled = busy;
+    button.textContent = nextLabel;
+  }
+
+  async function pickThreadWorkspace() {
+    const input = getThreadWorkspaceInput();
+    if (!input) {
+      return;
+    }
+    try {
+      setThreadWorkspacePickerBusy(true);
+      setThreadWorkspaceDescription(
+        "Opening the folder picker. If nothing appears, check whether the native dialog opened behind the browser window.",
+        { error: false },
+      );
+
+      const api = window.AcbApi && typeof window.AcbApi.api === "function"
+        ? window.AcbApi.api
+        : null;
+      if (api) {
+        const payload = await api("/api/system/pick-directory", {
+          method: "POST",
+          body: JSON.stringify({
+            current_path: String(input.value || "").trim() || undefined,
+          }),
+        });
+        const resolvedPath = String(payload?.path || "").trim();
+        if (resolvedPath) {
+          input.value = resolvedPath;
+          setThreadWorkspaceDescription(`Selected folder: ${resolvedPath}`);
+          return;
+        }
+        if (payload?.canceled) {
+          setThreadWorkspaceDescription("Folder selection canceled.", { error: false });
+          return;
+        }
+        if (payload?.detail) {
+          setThreadWorkspaceDescription(
+            `Could not open the native folder picker: ${String(payload.detail).trim()}`,
+            { error: true },
+          );
+        }
+      }
+      if (typeof window.showDirectoryPicker !== "function") {
+        setThreadWorkspaceDescription(
+          "Directory picking is unavailable here. Paste the full filesystem path manually.",
+          { error: false },
+        );
+        return;
+      }
+
+      const handle = await window.showDirectoryPicker({ mode: "read" });
+      const resolvedPath = typeof handle?.path === "string"
+        ? handle.path.trim()
+        : typeof handle?.fullPath === "string"
+          ? handle.fullPath.trim()
+          : "";
+      if (resolvedPath) {
+        input.value = resolvedPath;
+        setThreadWorkspaceDescription(`Selected folder: ${resolvedPath}`);
+        return;
+      }
+      const selectedName = String(handle?.name || "folder").trim() || "folder";
+      setThreadWorkspaceDescription(
+        `Selected "${selectedName}", but this browser cannot reveal its absolute path. Paste the full path manually.`,
+        { error: false },
+      );
+    } catch (error) {
+      if (error && typeof error === "object" && error.name === "AbortError") {
+        setThreadWorkspaceDescription("Folder selection canceled.", { error: false });
+        return;
+      }
+      setThreadWorkspaceDescription(
+        `Could not open the folder picker. Paste the full path manually.`,
+        { error: true },
+      );
+    } finally {
+      setThreadWorkspacePickerBusy(false);
+    }
+  }
+
   function getThreadLaunchGlobalInstruction() {
     return String(document.getElementById("thread-launch-global-instruction")?.value || "").trim();
   }
@@ -2015,6 +2197,7 @@
       participantAgent,
       config,
       isFirstAgent,
+      workspace,
     } = options;
     const result = await api(`/api/threads/${threadId}/cli-sessions`, {
       method: "POST",
@@ -2034,6 +2217,7 @@
         requested_by_agent_id: uiAgent.agent_id,
         participant_agent_id: participantAgent.agent_id,
         participant_display_name: participantAgent.display_name || buildDefaultParticipantName(config),
+        workspace: String(workspace || "").trim() || undefined,
         cols: 120,
         rows: 32,
       }),
@@ -2041,7 +2225,7 @@
     return result?.session || null;
   }
 
-  function openThreadModal(api) {
+  async function openThreadModal(api) {
     const launchPreviewDetailsEl = document.getElementById("thread-agent-side");
     const reentryPreviewDetailsEl = document.getElementById("thread-agent-reentry-side");
     if (launchPreviewDetailsEl instanceof HTMLDetailsElement) {
@@ -2058,6 +2242,8 @@
     if (topicInputEl && !String(topicInputEl.value || "").trim()) {
       topicInputEl.value = buildDefaultThreadName();
     }
+    clearThreadCreateError();
+    await loadThreadWorkspaceDefaults(api, { force: true });
     if (topicInputEl && topicInputEl.dataset.threadLaunchBound !== "1") {
       topicInputEl.dataset.threadLaunchBound = "1";
       topicInputEl.addEventListener("input", () => {
@@ -2124,6 +2310,9 @@
     const topicInput = document.getElementById("modal-topic");
     const topic = topicInput.value.trim();
     if (!topic) return;
+    clearThreadCreateError();
+    const workspaceInput = getThreadWorkspaceInput();
+    const workspace = String(workspaceInput?.value || "").trim();
 
     const modelInputs = Array.from(document.querySelectorAll('[data-field="model"]'));
     for (const input of modelInputs) {
@@ -2172,7 +2361,29 @@
       };
     }
 
+    const t = await api("/api/threads", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Agent-Token": creatorAuth.token,
+      },
+      body: JSON.stringify({
+        topic,
+        creator_agent_id: creatorAuth.agent_id,
+        assign_creator_admin: shouldLaunchFirstAgent,
+        workspace: workspace || undefined,
+        ...(template ? { template } : {}),
+      }),
+    });
+    if (!t?.id) {
+      setThreadCreateError(t?.detail || "Failed to create thread.");
+      return;
+    }
+
     topicInput.value = "";
+    if (workspaceInput) {
+      workspaceInput.value = "";
+    }
     if (templateSel) templateSel.value = "";
     const descEl = document.getElementById("modal-template-desc");
     if (descEl) descEl.textContent = "";
@@ -2184,19 +2395,6 @@
     syncThreadLaunchUi();
     closeThreadModal();
 
-    const t = await api("/api/threads", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Agent-Token": creatorAuth.token,
-      },
-      body: JSON.stringify({
-        topic,
-        creator_agent_id: creatorAuth.agent_id,
-        assign_creator_admin: shouldLaunchFirstAgent,
-        ...(template ? { template } : {}),
-      }),
-    });
     if (t) {
       const followupLaunchConfigs = shouldLaunchFirstAgent ? launchAgentConfigs.slice(1) : [];
       if (shouldLaunchFirstAgent && participantAgent && firstAgentConfig) {
@@ -2207,6 +2405,7 @@
           participantAgent,
           config: firstAgentConfig,
           isFirstAgent: true,
+          workspace,
         });
       }
       const syncContext =
@@ -2245,6 +2444,7 @@
           participantAgent: nextParticipantAgent,
           config,
           isFirstAgent: false,
+          workspace,
         });
         if (!session) {
           console.error(`[Thread Create] Failed to create target agent CLI session ${index + 2}`);
@@ -2352,6 +2552,150 @@
   function closeAddAgentModal(e) {
     if (!e || isOverlayClick(e, "agent")) {
       setModalVisible("agent", false);
+    }
+  }
+
+  function setRestartThreadError(message) {
+    const errorEl = document.getElementById("thread-restart-modal-error");
+    if (!errorEl) {
+      return;
+    }
+    const text = String(message || "").trim();
+    errorEl.textContent = text;
+    errorEl.classList.toggle("meeting-modal-hidden", !text);
+  }
+
+  function setRestartThreadSubmittingState(isSubmitting) {
+    const submitBtn = document.getElementById("thread-restart-submit-btn");
+    const cancelBtn = document.getElementById("thread-restart-cancel-btn");
+    const checkbox = document.getElementById("thread-restart-clear-workspace");
+    if (submitBtn) {
+      submitBtn.disabled = Boolean(isSubmitting);
+      submitBtn.textContent = isSubmitting ? "Restarting..." : "Restart Thread";
+    }
+    if (cancelBtn) {
+      cancelBtn.disabled = Boolean(isSubmitting);
+    }
+    if (checkbox) {
+      checkbox.disabled = Boolean(isSubmitting);
+    }
+  }
+
+  async function loadCurrentThreadSummary(api, threadId) {
+    if (!api || !threadId) {
+      return null;
+    }
+    const response = await api("/api/threads?include_archived=1");
+    const threads = Array.isArray(response?.threads) ? response.threads : [];
+    return threads.find((thread) => String(thread?.id || "").trim() === String(threadId || "").trim()) || null;
+  }
+
+  async function openRestartThreadModal(api) {
+    const threadId = window.currentThreadId;
+    if (!threadId) {
+      return;
+    }
+    setRestartThreadError("");
+    setRestartThreadSubmittingState(false);
+
+    const checkbox = document.getElementById("thread-restart-clear-workspace");
+    const workspaceInput = document.getElementById("thread-restart-modal-workspace");
+    const contextEl = document.getElementById("thread-restart-modal-context");
+    const threadTitle = document.getElementById("thread-title")?.textContent?.trim() || "current thread";
+    const threadSummary = await loadCurrentThreadSummary(api, threadId);
+    const workspace = String(threadSummary?.workspace || "").trim();
+
+    if (checkbox) {
+      checkbox.checked = false;
+    }
+    if (workspaceInput) {
+      workspaceInput.value = workspace || "(No workspace configured)";
+    }
+    if (contextEl) {
+      contextEl.textContent = `Restart "${threadTitle}" as a brand new thread. Existing discussion records are removed only after the replacement thread and agent launches succeed.`;
+    }
+
+    setModalVisible("thread-restart", true);
+  }
+
+  function closeRestartThreadModal(e) {
+    if (!e || isOverlayClick(e, "thread-restart")) {
+      setRestartThreadError("");
+      setRestartThreadSubmittingState(false);
+      setModalVisible("thread-restart", false);
+    }
+  }
+
+  async function submitRestartThreadModal(deps) {
+    const { api, refreshThreads, selectThread } = deps;
+    const threadId = window.currentThreadId;
+    if (!threadId) {
+      return;
+    }
+
+    const uiAgent = window.AcbUiAgent ? await window.AcbUiAgent.ensureUiAgent() : null;
+    if (!uiAgent) {
+      setRestartThreadError("Could not obtain the Browser User token needed to restart this thread.");
+      return;
+    }
+
+    const clearWorkspace = document.getElementById("thread-restart-clear-workspace")?.checked === true;
+    const wasPinned = !!window.AcbThreads?.isThreadPinned?.(threadId);
+    setRestartThreadError("");
+    setRestartThreadSubmittingState(true);
+
+    try {
+      const result = await api(`/api/threads/${threadId}/restart`, {
+        method: "POST",
+        headers: {
+          "X-Agent-Token": uiAgent.token,
+        },
+        body: JSON.stringify({
+          requested_by_agent_id: uiAgent.agent_id,
+          clear_workspace: clearWorkspace,
+        }),
+      });
+
+      if (!result?.ok || !result?.new_thread?.id) {
+        setRestartThreadError(result?.detail || "Failed to restart the thread.");
+        setRestartThreadSubmittingState(false);
+        return;
+      }
+
+      const nextThread = result.new_thread;
+      if (wasPinned && window.AcbThreads?.setThreadPinned) {
+        window.AcbThreads.setThreadPinned(threadId, false);
+        window.AcbThreads.setThreadPinned(nextThread.id, true);
+      }
+
+      closeRestartThreadModal();
+
+      if (typeof refreshThreads === "function") {
+        await refreshThreads();
+      }
+
+      const syncContext =
+        typeof nextThread.current_seq === "number" && nextThread.reply_token
+          ? {
+              current_seq: nextThread.current_seq,
+              reply_token: nextThread.reply_token,
+              reply_window: nextThread.reply_window || null,
+            }
+          : null;
+
+      if (typeof selectThread === "function") {
+        await selectThread(nextThread.id, nextThread.topic, nextThread.status, syncContext);
+      }
+
+      if (window.AcbChat && typeof window.AcbChat.refreshThreadAdmin === "function") {
+        await window.AcbChat.refreshThreadAdmin(nextThread.id, api);
+      }
+      if (window.AcbCliSessions && typeof window.AcbCliSessions.refreshThread === "function") {
+        await window.AcbCliSessions.refreshThread(nextThread.id, api);
+      }
+    } catch (error) {
+      setRestartThreadError(error instanceof Error ? error.message : String(error));
+      setRestartThreadSubmittingState(false);
     }
   }
 
@@ -2829,9 +3173,13 @@
     removeThreadLaunchAgent,
     selectThreadLaunchAgent,
     updateThreadLaunchAgentField,
+    pickThreadWorkspace,
     openAddAgentModal,
     closeAddAgentModal,
     submitAddAgentModal,
+    openRestartThreadModal,
+    closeRestartThreadModal,
+    submitRestartThreadModal,
     switchAddAgentTab,
     openSettingsModal,
     closeSettingsModal,
@@ -2859,6 +3207,19 @@
     return openAddAgentModal(api);
   };
   window.closeAddAgentModal = closeAddAgentModal;
+  window.openRestartThreadModal = function() {
+    const api = _resolveApi();
+    return openRestartThreadModal(api);
+  };
+  window.closeRestartThreadModal = closeRestartThreadModal;
+  window.submitRestartThreadModal = function() {
+    const api = _resolveApi();
+    return submitRestartThreadModal({
+      api,
+      refreshThreads: typeof window.refreshThreads === "function" ? window.refreshThreads : null,
+      selectThread: typeof window.selectThread === "function" ? window.selectThread : null,
+    });
+  };
   window.submitAddAgentModal = function() {
     const api = _resolveApi();
     return submitAddAgentModal({


### PR DESCRIPTION
## Summary

- Sync **Restart Thread** UI from `web-ui/` into `agentchatbus-ts/web-ui/` and `vscode-agentchatbus/resources/web-ui/`.
- No new API or behavior: exposes the existing `POST /api/threads/:threadId/restart` endpoint (added in 74d40a1) in the bundled server and VS Code extension UI paths.
- Produced via official `npm run sync:webui` + extension `sync:webui-assets` (not hand-edited copies).

## Context

The header button and modal lived only under root `web-ui/` while the TS server and extension ship `agentchatbus-ts/web-ui/`. Daily use through the extension therefore missed Restart Thread even though the backend and integration tests were already there.

## Test plan

- [x] `npm run sync:webui` — `web-ui` and `agentchatbus-ts/web-ui` hashes match for the three touched files
- [x] `vitest run tests/integration/threadRestartIntegration.test.ts` — 2/3 pass (workspace clear + non-git reject); 1 pre-existing failure on `timeout_seconds` propagation (60 vs 95), unrelated to this UI sync
- [ ] Manual: extension web console → open thread → **Restart Thread** in header → modal → confirm restart succeeds
