### PR TITLE
fix(thread-restart): preserve settings and prompt overrides on restart

### DIFF
--- a/agentchatbus-ts/src/transports/http/server.ts
+++ b/agentchatbus-ts/src/transports/http/server.ts
@@ -617,7 +617,9 @@ function createCliThreadSession(input: {
       participantDisplayName: participantDisplayName || undefined,
       initialInstruction: promptSeed,
     });
-    finalPrompt = prepared.prompt;
+    if (!exactPromptOverride) {
+      finalPrompt = prepared.prompt;
+    }
     participantRole = prepared.participantRole;
     contextDeliveryMode = prepared.contextDeliveryMode;
     lastDeliveredSeq = prepared.lastDeliveredSeq;
@@ -2538,7 +2540,7 @@ export function createHttpServer() {
   fastify.post("/api/threads/:threadId/settings", async (request, reply) => {
     const params = request.params as { threadId: string };
     const body = request.body as JsonBody;
-    const settings = memoryStore.updateThreadSettings(params.threadId, {
+    const settings = store.updateThreadSettings(params.threadId, {
       auto_administrator_enabled: typeof body.auto_administrator_enabled === "boolean" ? body.auto_administrator_enabled : undefined,
       timeout_seconds: typeof body.timeout_seconds === "number" ? body.timeout_seconds : undefined,
       switch_timeout_seconds: typeof body.switch_timeout_seconds === "number" ? body.switch_timeout_seconds : undefined


### PR DESCRIPTION
## Summary
- Fix `POST /api/threads/:id/settings` to use the per-server `store` instance instead of the global `memoryStore` singleton (broken when `AGENTCHATBUS_TEST_DB` or a dedicated DB binding is active).
- Preserve explicit CLI `prompt` overrides in `createCliThreadSession` so thread restart replays stored blueprint prompts instead of rebuilding meeting prompts.

## Context
`threadRestartIntegration` failed on `timeout_seconds` (60 vs 95) because settings updates never reached the test store. After that fix, the same test exposed a second bug: `exactPromptOverride` was overwritten by `prepareSession` before session creation.

## Test plan
- [x] `vitest run tests/integration/threadRestartIntegration.test.ts` — 3/3 pass
- [x] `vitest run tests/unit/test_thread_settings.test.ts tests/unit/test_thread_settings_v2_basic.test.ts` — 21/21 pass
