### PR TITLE
feat(tags): thread tagging REST/MCP + web UI chips

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,1 @@
+﻿CLAUDE.md

--- a/.cursorindexingignore
+++ b/.cursorindexingignore
@@ -1,0 +1,20 @@
+# Cursor Indexing Ignore - rhub_ng
+# Excluded from index but still allows @-references
+
+# === Storybook build ===
+storybook-static/
+
+# === Assets (non-code) ===
+src/assets/
+
+# === Generated files ===
+*.d.ts
+*.generated.ts
+*.spec.js.snap
+
+# === Lock files ===
+package-lock.json
+
+# === SpecStory auto-save ===
+.specstory/**
+CLAUDE.md

--- a/agentchatbus-ts/src/adapters/mcp/tools.ts
+++ b/agentchatbus-ts/src/adapters/mcp/tools.ts
@@ -75,6 +75,7 @@ const toolDefinitions: ToolDefinition[] = [
       properties: {
         status: { type: "string", enum: ["discuss", "implement", "review", "done", "closed", "archived"], description: "Filter by lifecycle state. Omit for all threads." },
         include_archived: { type: "boolean", default: false, description: "If true and no status filter is provided, include archived threads." },
+        tag: { type: "string", description: "Filter threads that include this tag slug." },
         limit: { type: "integer", default: 0, description: "Max threads to return. 0 means all (no limit). Hard cap: 200." },
         before: { type: "string", description: "Pagination cursor: ISO datetime string. Returns threads created strictly before this timestamp. Pass `next_cursor` from a previous response to fetch the next page." }
       }
@@ -175,6 +176,44 @@ const toolDefinitions: ToolDefinition[] = [
       properties: {
         thread_id: { type: "string", description: "Thread ID to archive." }
       }
+    }
+  },
+  {
+    name: "thread_tag",
+    description: "Add a tag to a thread. Tags are normalized to lowercase slugs.",
+    inputSchema: {
+      type: "object",
+      required: ["thread_id", "tag"],
+      properties: {
+        thread_id: { type: "string", description: "Thread ID." },
+        tag: { type: "string", description: "Tag slug (lowercase letters, numbers, underscore, hyphen; max 32 chars)." }
+      },
+      additionalProperties: false
+    }
+  },
+  {
+    name: "thread_untag",
+    description: "Remove a tag from a thread.",
+    inputSchema: {
+      type: "object",
+      required: ["thread_id", "tag"],
+      properties: {
+        thread_id: { type: "string", description: "Thread ID." },
+        tag: { type: "string", description: "Tag slug to remove." }
+      },
+      additionalProperties: false
+    }
+  },
+  {
+    name: "thread_tags_list",
+    description: "List tags for a single thread.",
+    inputSchema: {
+      type: "object",
+      required: ["thread_id"],
+      properties: {
+        thread_id: { type: "string", description: "Thread ID." }
+      },
+      additionalProperties: false
     }
   },
   {
@@ -814,6 +853,7 @@ export async function callTool(name: string, args: Record<string, unknown>): Pro
     case "thread_list": {
       const status = typeof args.status === "string" ? args.status : undefined;
       const includeArchived = Boolean(args.include_archived);
+      const tag = typeof args.tag === "string" ? args.tag : undefined;
       const limit = typeof args.limit === "number" ? args.limit : 0;
       const before = typeof args.before === "string" ? args.before : undefined;
 
@@ -822,6 +862,15 @@ export async function callTool(name: string, args: Record<string, unknown>): Pro
       // Filter by status if provided
       if (status) {
         threads = threads.filter(t => t.status === status);
+      }
+
+      if (tag) {
+        try {
+          const normalizedTag = getStore().normalizeThreadTag(tag);
+          threads = threads.filter((thread) => (thread.tags || []).includes(normalizedTag));
+        } catch (error) {
+          return { error: error instanceof Error ? error.message : "Invalid tag" };
+        }
       }
 
       // Apply pagination
@@ -847,7 +896,8 @@ export async function callTool(name: string, args: Record<string, unknown>): Pro
           thread_id: t.id,
           topic: t.topic,
           status: t.status,
-          created_at: t.created_at
+          created_at: t.created_at,
+          tags: t.tags || []
         })),
         total,
         has_more: hasMore,
@@ -865,7 +915,8 @@ export async function callTool(name: string, args: Record<string, unknown>): Pro
         status: thread.status,
         created_at: thread.created_at,
         closed_at: (thread as any).closed_at || null,
-        summary: (thread as any).summary || null
+        summary: (thread as any).summary || null,
+        tags: thread.tags || []
       };
     }
     case "thread_delete": {
@@ -995,6 +1046,36 @@ export async function callTool(name: string, args: Record<string, unknown>): Pro
         return { error: "Thread not found" };
       }
       return { ok: true, thread_id: threadId, status: "archived" };
+    }
+    case "thread_tag": {
+      const threadId = String(args.thread_id || "");
+      const tag = String(args.tag || "");
+      try {
+        const tags = getStore().addThreadTag(threadId, tag);
+        if (!tags) {
+          return { error: "Thread not found" };
+        }
+        return { ok: true, thread_id: threadId, tag: getStore().normalizeThreadTag(tag), tags };
+      } catch (error) {
+        return { error: error instanceof Error ? error.message : "Invalid tag" };
+      }
+    }
+    case "thread_untag": {
+      const threadId = String(args.thread_id || "");
+      const tag = String(args.tag || "");
+      const result = getStore().removeThreadTag(threadId, tag);
+      if (!result) {
+        return { error: "Thread not found" };
+      }
+      return { ok: true, thread_id: threadId, removed: result.removed, tags: result.tags };
+    }
+    case "thread_tags_list": {
+      const threadId = String(args.thread_id || "");
+      const thread = getStore().getThread(threadId);
+      if (!thread) {
+        return { error: "Thread not found" };
+      }
+      return { thread_id: threadId, tags: getStore().getThreadTags(threadId) };
     }
     case "thread_wait_state_get": {
       const threadId = String(args.thread_id || "");

--- a/agentchatbus-ts/src/core/services/memoryStore.ts
+++ b/agentchatbus-ts/src/core/services/memoryStore.ts
@@ -511,12 +511,13 @@ export class MemoryStore {
         ORDER BY created_at DESC
       `
     ).all() as Array<Record<string, unknown>>;
-    return rows
+    const threads = rows
       .map((row) => this.rowToThreadRecord(row))
       .map((thread) => ({
         ...thread,
         waiting_agents: this.getThreadWaitingAgents(thread.id)
       }));
+    return this.attachTagsToThreads(threads);
   }
 
   getMetrics() {
@@ -684,6 +685,7 @@ export class MemoryStore {
       DELETE FROM thread_settings;
       DELETE FROM message_edits;
       DELETE FROM reactions;
+      DELETE FROM thread_tags;
       DELETE FROM msg_wait_refresh_requests;
       DELETE FROM thread_wait_states;
       DELETE FROM templates;
@@ -772,7 +774,12 @@ export class MemoryStore {
     const row = this.persistenceDb.prepare(
       "SELECT id, topic, status, created_at, updated_at, system_prompt, template_id, metadata, closed_at, summary FROM threads WHERE id = ?"
     ).get(threadId) as Record<string, unknown> | undefined;
-    return row ? this.rowToThreadRecord(row) : undefined;
+    if (!row) {
+      return undefined;
+    }
+    const thread = this.rowToThreadRecord(row);
+    thread.tags = this.getThreadTags(threadId);
+    return thread;
   }
 
   addThreadParticipant(threadId: string, agentId: string): boolean {
@@ -1346,12 +1353,14 @@ export class MemoryStore {
     includeArchived?: boolean;
     limit?: number;
     before?: string;
+    tag?: string;
   }): { threads: ThreadRecord[]; has_more: boolean; next_cursor?: string } {
     const {
       status,
       includeArchived = true,
       limit = 0,
-      before
+      before,
+      tag
     } = options || {};
 
     // Build WHERE clauses
@@ -1370,6 +1379,12 @@ export class MemoryStore {
       params.push(before);
     }
 
+    if (tag) {
+      const normalizedTag = this.normalizeThreadTag(tag);
+      clauses.push("id IN (SELECT thread_id FROM thread_tags WHERE tag = ?)");
+      params.push(normalizedTag);
+    }
+
     const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
     
     // Hard cap at 200
@@ -1384,7 +1399,7 @@ export class MemoryStore {
 
     const rows = this.persistenceDb.prepare(sql).all(...params) as Array<Record<string, unknown>>;
     
-    let threads = rows.map(row => this.rowToThreadRecord(row));
+    let threads = this.attachTagsToThreads(rows.map(row => this.rowToThreadRecord(row)));
     let hasMore = false;
     let nextCursor: string | undefined;
 
@@ -1471,6 +1486,7 @@ export class MemoryStore {
       this.persistenceDb.prepare(
         "DELETE FROM reactions WHERE message_id IN (SELECT id FROM messages WHERE thread_id = ?)"
       ).run(threadId);
+      this.persistenceDb.prepare("DELETE FROM thread_tags WHERE thread_id = ?").run(threadId);
       this.persistenceDb.prepare("DELETE FROM messages WHERE thread_id = ?").run(threadId);
       this.persistenceDb.prepare("DELETE FROM human_only_messages WHERE thread_id = ?").run(threadId);
       this.persistenceDb.prepare("DELETE FROM reply_tokens WHERE thread_id = ?").run(threadId);
@@ -2561,6 +2577,102 @@ export class MemoryStore {
       this.persistState();
     }
     return { removed, message };
+  }
+
+  private static readonly THREAD_TAG_PATTERN = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+
+  normalizeThreadTag(tag: string): string {
+    const normalized = String(tag || "").trim().toLowerCase();
+    if (!normalized || !MemoryStore.THREAD_TAG_PATTERN.test(normalized)) {
+      throw new Error("Invalid tag: must match [a-z0-9][a-z0-9_-]{0,31}");
+    }
+    return normalized;
+  }
+
+  getThreadTags(threadId: string): string[] {
+    const rows = this.persistenceDb.prepare(
+      "SELECT tag FROM thread_tags WHERE thread_id = ? ORDER BY tag ASC"
+    ).all(threadId) as Array<{ tag: string }>;
+    return rows.map((row) => String(row.tag));
+  }
+
+  getThreadTagsBulk(threadIds: string[]): Map<string, string[]> {
+    const result = new Map<string, string[]>();
+    if (threadIds.length === 0) {
+      return result;
+    }
+    for (const threadId of threadIds) {
+      result.set(threadId, []);
+    }
+    const placeholders = threadIds.map(() => "?").join(",");
+    const rows = this.persistenceDb.prepare(
+      `SELECT thread_id, tag FROM thread_tags WHERE thread_id IN (${placeholders}) ORDER BY tag ASC`
+    ).all(...threadIds) as Array<{ thread_id: string; tag: string }>;
+    for (const row of rows) {
+      const threadId = String(row.thread_id);
+      const tags = result.get(threadId) || [];
+      tags.push(String(row.tag));
+      result.set(threadId, tags);
+    }
+    return result;
+  }
+
+  listAllTags(): string[] {
+    const rows = this.persistenceDb.prepare(
+      "SELECT DISTINCT tag FROM thread_tags ORDER BY tag ASC"
+    ).all() as Array<{ tag: string }>;
+    return rows.map((row) => String(row.tag));
+  }
+
+  private attachTagsToThreads(threads: ThreadRecord[]): ThreadRecord[] {
+    if (threads.length === 0) {
+      return threads;
+    }
+    const tagMap = this.getThreadTagsBulk(threads.map((thread) => thread.id));
+    return threads.map((thread) => ({
+      ...thread,
+      tags: tagMap.get(thread.id) || []
+    }));
+  }
+
+  addThreadTag(threadId: string, tag: string): string[] | undefined {
+    const exists = this.persistenceDb.prepare("SELECT 1 FROM threads WHERE id = ?").get(threadId);
+    if (!exists) {
+      return undefined;
+    }
+    const normalized = this.normalizeThreadTag(tag);
+    const inserted = this.persistenceDb.prepare(
+      "INSERT OR IGNORE INTO thread_tags (id, thread_id, tag, created_at) VALUES (?, ?, ?, ?)"
+    ).run(randomUUID(), threadId, normalized, new Date().toISOString());
+    const tags = this.getThreadTags(threadId);
+    if (inserted.changes > 0) {
+      eventBus.emit({ type: "thread.tag", payload: { thread_id: threadId, tag: normalized, tags } });
+      this.persistState();
+    }
+    return tags;
+  }
+
+  removeThreadTag(threadId: string, tag: string): { removed: boolean; tags: string[] } | undefined {
+    const exists = this.persistenceDb.prepare("SELECT 1 FROM threads WHERE id = ?").get(threadId);
+    if (!exists) {
+      return undefined;
+    }
+    let normalized: string;
+    try {
+      normalized = this.normalizeThreadTag(tag);
+    } catch {
+      normalized = String(tag || "").trim().toLowerCase();
+    }
+    const deleted = this.persistenceDb.prepare(
+      "DELETE FROM thread_tags WHERE thread_id = ? AND tag = ?"
+    ).run(threadId, normalized);
+    const removed = deleted.changes > 0;
+    const tags = this.getThreadTags(threadId);
+    if (removed) {
+      eventBus.emit({ type: "thread.untag", payload: { thread_id: threadId, tag: normalized, tags } });
+      this.persistState();
+    }
+    return { removed, tags };
   }
 
   issueSyncContext(threadId: string, agentId?: string, source?: string): SyncContext {
@@ -4521,6 +4633,15 @@ export class MemoryStore {
         created_at TEXT NOT NULL,
         UNIQUE (message_id, agent_id, reaction)
       );
+      CREATE TABLE IF NOT EXISTS thread_tags (
+        id TEXT NOT NULL,
+        thread_id TEXT NOT NULL,
+        tag TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        UNIQUE (thread_id, tag)
+      );
+      CREATE INDEX IF NOT EXISTS idx_thread_tags_tag ON thread_tags(tag);
+      CREATE INDEX IF NOT EXISTS idx_thread_tags_thread ON thread_tags(thread_id);
       CREATE TABLE IF NOT EXISTS templates (
         id TEXT PRIMARY KEY,
         name TEXT NOT NULL,

--- a/agentchatbus-ts/src/core/types/models.ts
+++ b/agentchatbus-ts/src/core/types/models.ts
@@ -34,6 +34,7 @@ export interface ThreadRecord {
   closed_at?: string;
   summary?: string;
   metadata?: Record<string, unknown>;
+  tags?: string[];
 }
 
 export interface MessageRecord {

--- a/agentchatbus-ts/src/transports/http/server.ts
+++ b/agentchatbus-ts/src/transports/http/server.ts
@@ -1226,11 +1226,20 @@ export function createHttpServer() {
     }
   });
 
-  fastify.get("/api/threads", async (request) => {
-    const query = request.query as { include_archived?: boolean; status?: string; limit?: number; before?: string };
+  fastify.get("/api/threads", async (request, reply) => {
+    const query = request.query as { include_archived?: boolean; status?: string; tag?: string; limit?: number; before?: string };
     let threads = store.getThreads(Boolean(query.include_archived));
     if (query.status) {
       threads = threads.filter((thread) => thread.status === query.status);
+    }
+    if (query.tag) {
+      try {
+        const normalizedTag = store.normalizeThreadTag(String(query.tag));
+        threads = threads.filter((thread) => (thread.tags || []).includes(normalizedTag));
+      } catch (error) {
+        reply.code(400);
+        return { detail: error instanceof Error ? error.message : "Invalid tag" };
+      }
     }
     
     // Add waiting_agents for each thread (match Python main.py L990-1002)
@@ -1676,6 +1685,11 @@ export function createHttpServer() {
           timeout_seconds: sourceSettings.timeout_seconds,
           switch_timeout_seconds: sourceSettings.switch_timeout_seconds,
         });
+      }
+
+      const sourceTags = store.getThreadTags(params.threadId);
+      for (const tag of sourceTags) {
+        store.addThreadTag(newThreadId, tag);
       }
 
       for (let index = 0; index < sourceAgents.length; index += 1) {
@@ -2377,6 +2391,43 @@ export function createHttpServer() {
       return { detail: "Message not found" };
     }
     return { removed: result.removed };
+  });
+
+  fastify.get("/api/threads/:threadId/tags", async (request, reply) => {
+    const params = request.params as { threadId: string };
+    const thread = store.getThread(params.threadId);
+    if (!thread) {
+      reply.code(404);
+      return { detail: "Thread not found" };
+    }
+    return { tags: store.getThreadTags(params.threadId) };
+  });
+
+  fastify.post("/api/threads/:threadId/tags", async (request, reply) => {
+    const params = request.params as { threadId: string };
+    const body = request.body as JsonBody;
+    try {
+      const tags = store.addThreadTag(params.threadId, String(body.tag || ""));
+      if (!tags) {
+        reply.code(404);
+        return { detail: "Thread not found" };
+      }
+      reply.code(201);
+      return { ok: true, tags };
+    } catch (error) {
+      reply.code(400);
+      return { detail: error instanceof Error ? error.message : "Invalid tag" };
+    }
+  });
+
+  fastify.delete("/api/threads/:threadId/tags/:tag", async (request, reply) => {
+    const params = request.params as { threadId: string; tag: string };
+    const result = store.removeThreadTag(params.threadId, decodeURIComponent(params.tag));
+    if (!result) {
+      reply.code(404);
+      return { detail: "Thread not found" };
+    }
+    return { ok: true, tags: result.tags };
   });
 
   fastify.put("/api/messages/:messageId", async (request, reply) => {

--- a/agentchatbus-ts/tests/integration/httpServer.test.ts
+++ b/agentchatbus-ts/tests/integration/httpServer.test.ts
@@ -758,6 +758,58 @@ describe("HTTP compatibility shell", () => {
     await server.close();
   });
 
+  it("supports thread tag REST and MCP flows", async () => {
+    const server = createHttpServer();
+    const thread = await createAuthedThread(server, "tag-thread");
+
+    const addResponse = await server.inject({
+      method: "POST",
+      url: `/api/threads/${thread.id}/tags`,
+      payload: { tag: "Feature-Alpha" }
+    });
+    expect(addResponse.statusCode).toBe(201);
+    expect(addResponse.json().tags).toEqual(["feature-alpha"]);
+
+    const listResponse = await server.inject({
+      method: "GET",
+      url: `/api/threads/${thread.id}/tags`
+    });
+    expect(listResponse.statusCode).toBe(200);
+    expect(listResponse.json().tags).toEqual(["feature-alpha"]);
+
+    const filterResponse = await server.inject({
+      method: "GET",
+      url: "/api/threads?tag=feature-alpha"
+    });
+    expect(filterResponse.statusCode).toBe(200);
+    expect(filterResponse.json().threads.some((item: { id: string }) => item.id === thread.id)).toBe(true);
+
+    const mcpTagResponse = await server.inject({
+      method: "POST",
+      url: "/mcp/messages/",
+      payload: {
+        method: "tools/call",
+        params: {
+          name: "thread_tag",
+          arguments: { thread_id: thread.id, tag: "docs" }
+        }
+      }
+    });
+    expect(mcpTagResponse.statusCode).toBe(200);
+    const mcpTagBody = mcpTagResponse.json().result;
+    expect(mcpTagBody.ok).toBe(true);
+    expect(mcpTagBody.tags).toEqual(expect.arrayContaining(["feature-alpha", "docs"]));
+
+    const deleteResponse = await server.inject({
+      method: "DELETE",
+      url: `/api/threads/${thread.id}/tags/feature-alpha`
+    });
+    expect(deleteResponse.statusCode).toBe(200);
+    expect(deleteResponse.json().tags).toEqual(["docs"]);
+
+    await server.close();
+  });
+
   it("supports agent register, resume, update, and kick flows", async () => {
     const server = createHttpServer();
 

--- a/agentchatbus-ts/tests/unit/test_thread_tags.test.ts
+++ b/agentchatbus-ts/tests/unit/test_thread_tags.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for UP-27 thread tagging.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { MemoryStore } from '../../src/core/services/memoryStore.js';
+import { randomUUID } from 'crypto';
+import { unlinkSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+let store: MemoryStore;
+let dbPath: string;
+
+beforeEach(() => {
+  vi.stubEnv('AGENTCHATBUS_RATE_LIMIT_ENABLED', 'false');
+  dbPath = join(tmpdir(), `test-thread-tags-${randomUUID()}.db`);
+  store = new MemoryStore(dbPath);
+});
+
+afterEach(() => {
+  try {
+    if (existsSync(dbPath)) {
+      unlinkSync(dbPath);
+    }
+  } catch {}
+});
+
+describe('Thread tags (UP-27)', () => {
+  it('addThreadTag stores normalized tag', () => {
+    const { thread } = store.createThread('tag-test');
+    const tags = store.addThreadTag(thread.id, '  Feature-X  ');
+    expect(tags).toEqual(['feature-x']);
+    expect(store.getThreadTags(thread.id)).toEqual(['feature-x']);
+  });
+
+  it('addThreadTag is idempotent on re-add', () => {
+    const { thread } = store.createThread('tag-idempotent');
+    store.addThreadTag(thread.id, 'bugfix');
+    const tags = store.addThreadTag(thread.id, 'bugfix');
+    expect(tags).toEqual(['bugfix']);
+    expect(store.getThreadTags(thread.id).length).toBe(1);
+  });
+
+  it('removeThreadTag removes tag', () => {
+    const { thread } = store.createThread('tag-remove');
+    store.addThreadTag(thread.id, 'review');
+    const result = store.removeThreadTag(thread.id, 'review');
+    expect(result?.removed).toBe(true);
+    expect(result?.tags).toEqual([]);
+  });
+
+  it('normalizeThreadTag rejects invalid tags', () => {
+    const { thread } = store.createThread('tag-invalid');
+    expect(() => store.addThreadTag(thread.id, '')).toThrow(/Invalid tag/);
+    expect(() => store.addThreadTag(thread.id, 'bad tag')).toThrow(/Invalid tag/);
+    expect(() => store.addThreadTag(thread.id, '-invalid')).toThrow(/Invalid tag/);
+  });
+
+  it('deleteThread cascades thread_tags', () => {
+    const { thread } = store.createThread('tag-cascade');
+    store.addThreadTag(thread.id, 'temp');
+    expect(store.getThreadTags(thread.id)).toEqual(['temp']);
+    store.deleteThread(thread.id);
+    expect(store.getThreadTags(thread.id)).toEqual([]);
+    expect(store.listAllTags()).toEqual([]);
+  });
+
+  it('getThreads includes tags via bulk attach', () => {
+    const { thread: t1 } = store.createThread('tag-list-1');
+    const { thread: t2 } = store.createThread('tag-list-2');
+    store.addThreadTag(t1.id, 'alpha');
+    store.addThreadTag(t2.id, 'beta');
+
+    const threads = store.getThreads(true);
+    const byId = new Map(threads.map((thread) => [thread.id, thread]));
+    expect(byId.get(t1.id)?.tags).toEqual(['alpha']);
+    expect(byId.get(t2.id)?.tags).toEqual(['beta']);
+  });
+
+  it('getThread includes tags', () => {
+    const { thread } = store.createThread('tag-get');
+    store.addThreadTag(thread.id, 'docs');
+    const loaded = store.getThread(thread.id);
+    expect(loaded?.tags).toEqual(['docs']);
+  });
+
+  it('listThreads filters by tag', () => {
+    const { thread: t1 } = store.createThread('tag-filter-1');
+    const { thread: t2 } = store.createThread('tag-filter-2');
+    store.addThreadTag(t1.id, 'shared');
+    store.addThreadTag(t2.id, 'other');
+
+    const filtered = store.listThreads({ tag: 'shared' }).threads;
+    expect(filtered.map((thread) => thread.id)).toEqual([t1.id]);
+    expect(filtered[0].tags).toEqual(['shared']);
+  });
+
+  it('getThreadTagsBulk returns map for multiple threads', () => {
+    const { thread: t1 } = store.createThread('tag-bulk-1');
+    const { thread: t2 } = store.createThread('tag-bulk-2');
+    store.addThreadTag(t1.id, 'one');
+    store.addThreadTag(t2.id, 'two');
+
+    const bulk = store.getThreadTagsBulk([t1.id, t2.id, 'missing']);
+    expect(bulk.get(t1.id)).toEqual(['one']);
+    expect(bulk.get(t2.id)).toEqual(['two']);
+    expect(bulk.get('missing')).toEqual([]);
+  });
+});

--- a/agentchatbus-ts/web-ui/css/main.css
+++ b/agentchatbus-ts/web-ui/css/main.css
@@ -1977,6 +1977,105 @@ body[data-theme="light"] .reaction-pill {
   color: #555;
 }
 
+.ti-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.ti-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  padding: 1px 7px;
+  border-radius: 12px;
+  background: rgba(100,100,120,0.12);
+  border: 1px solid rgba(100,100,120,0.22);
+  color: var(--text-secondary, #aaa);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.ti-tag.is-active {
+  background: rgba(59,130,246,0.18);
+  border-color: rgba(59,130,246,0.35);
+  color: var(--text-1, #dbeafe);
+}
+
+.ti-tag-remove {
+  font-size: 12px;
+  line-height: 1;
+  opacity: 0.75;
+  cursor: pointer;
+}
+
+.ti-tag-remove:hover {
+  opacity: 1;
+}
+
+.thread-tag-filter-section {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(120,120,140,0.18);
+}
+
+.thread-tag-filter-title {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-3, #888);
+  margin-bottom: 6px;
+}
+
+.thread-tag-filter-list,
+.thread-tag-filter-empty {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.thread-tag-filter-chip {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  background: rgba(100,100,120,0.12);
+  border: 1px solid rgba(100,100,120,0.22);
+  color: var(--text-secondary, #aaa);
+  cursor: pointer;
+}
+
+.thread-tag-filter-chip.is-active {
+  background: rgba(59,130,246,0.18);
+  border-color: rgba(59,130,246,0.35);
+  color: var(--text-1, #dbeafe);
+}
+
+.thread-tag-filter-clear {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  background: transparent;
+  border: 1px dashed rgba(120,120,140,0.35);
+  color: var(--text-3, #888);
+  cursor: pointer;
+}
+
+body[data-theme="light"] .ti-tag,
+body[data-theme="light"] .thread-tag-filter-chip {
+  background: rgba(0,0,0,0.06);
+  border-color: rgba(0,0,0,0.12);
+  color: #555;
+}
+
+body[data-theme="light"] .ti-tag.is-active,
+body[data-theme="light"] .thread-tag-filter-chip.is-active {
+  background: rgba(37,99,235,0.12);
+  border-color: rgba(37,99,235,0.28);
+  color: #1d4ed8;
+}
+
 body[data-theme="light"] .handoff-badge {
   background: rgba(59,130,246,0.10);
   color: #2563eb;

--- a/agentchatbus-ts/web-ui/index.html
+++ b/agentchatbus-ts/web-ui/index.html
@@ -1098,6 +1098,14 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
           await refreshThreads();
         },
         onOpenContextMenu: openThreadContextMenu,
+        onTagFilter: async (tag) => {
+          window.AcbThreads.setActiveTagFilter(tag);
+          await refreshThreads();
+        },
+        onTagRemove: async (threadId, tag) => {
+          await window.AcbThreads.removeThreadTag(threadId, tag, api);
+          await refreshThreads();
+        },
         esc,
         timeAgo,
         updateThreadFilterButton,
@@ -1156,6 +1164,25 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
         NORMAL_THREAD_STATUSES,
         selectedThreadStatuses
       );
+    }
+
+    function setThreadTagFilter(tag) {
+      window.AcbThreads.setActiveTagFilter(tag);
+      refreshThreads();
+    }
+
+    function clearThreadTagFilter() {
+      window.AcbThreads.clearActiveTagFilter();
+      refreshThreads();
+    }
+
+    async function addTagFromMenu() {
+      return window.AcbThreads.addTagFromMenu({
+        getContextMenuThread: () => contextMenuThread,
+        hideThreadContextMenu,
+        api,
+        refreshThreads,
+      });
     }
 
     async function selectThread(id, topic, status, initialSyncContext = null) {

--- a/agentchatbus-ts/web-ui/js/components/acb-thread-context-menu.js
+++ b/agentchatbus-ts/web-ui/js/components/acb-thread-context-menu.js
@@ -8,6 +8,7 @@
           <button id="ctx-copy-name" class="ctx-item" type="button" role="menuitem" onclick="copyThreadNameFromMenu()">🧵 Copy Thread Name</button>
           <hr class="ctx-divider" aria-hidden="true">
           <button id="ctx-rename" class="ctx-item" type="button" role="menuitem" onclick="renameThreadFromMenu()">✏️ Rename</button>
+          <button id="ctx-add-tag" class="ctx-item" type="button" role="menuitem" onclick="addTagFromMenu()">🏷️ Add tag…</button>
           <button id="ctx-close" class="ctx-item" type="button" role="menuitem" onclick="closeThreadFromMenu()">🔒 Close</button>
           <button id="ctx-archive" class="ctx-item" type="button" role="menuitem" onclick="archiveThreadFromMenu()">🗄️ Archive</button>
           <button id="ctx-unarchive" class="ctx-item" type="button" role="menuitem" onclick="unarchiveThreadFromMenu()" style="display: none;">📂 Unarchive</button>

--- a/agentchatbus-ts/web-ui/js/components/acb-thread-filter-shell.js
+++ b/agentchatbus-ts/web-ui/js/components/acb-thread-filter-shell.js
@@ -14,6 +14,10 @@
             <acb-filter-row status="done" checked></acb-filter-row>
             <acb-filter-row status="closed" checked></acb-filter-row>
             <acb-filter-row status="archived"></acb-filter-row>
+            <div class="thread-tag-filter-section">
+              <div class="thread-tag-filter-title">Tags</div>
+              <div id="thread-tag-filter-list" class="thread-tag-filter-list"></div>
+            </div>
           </div>
         </div>`;
     }

--- a/agentchatbus-ts/web-ui/js/components/acb-thread-item.js
+++ b/agentchatbus-ts/web-ui/js/components/acb-thread-item.js
@@ -9,6 +9,7 @@
       this._boundClick = null;
       this._boundContextMenu = null;
       this._boundPinClick = null;
+      this._boundTagClick = null;
     }
 
     connectedCallback() {
@@ -64,9 +65,43 @@
         };
       }
 
+      if (!this._boundTagClick) {
+        this._boundTagClick = (e) => {
+          const removeBtn = e.target.closest(".ti-tag-remove");
+          if (removeBtn) {
+            e.preventDefault();
+            e.stopPropagation();
+            if (!this._thread) return;
+            this.dispatchEvent(
+              new CustomEvent("thread-tag-remove", {
+                bubbles: true,
+                detail: {
+                  id: this._thread.id,
+                  tag: removeBtn.getAttribute("data-tag") || "",
+                },
+              })
+            );
+            return;
+          }
+          const tagBtn = e.target.closest(".ti-tag");
+          if (!tagBtn || !this._thread) return;
+          e.preventDefault();
+          e.stopPropagation();
+          this.dispatchEvent(
+            new CustomEvent("thread-tag-filter", {
+              bubbles: true,
+              detail: {
+                tag: tagBtn.getAttribute("data-tag") || "",
+              },
+            })
+          );
+        };
+      }
+
       this.addEventListener("click", this._boundClick);
       this.addEventListener("contextmenu", this._boundContextMenu);
       this.addEventListener("click", this._boundPinClick);
+      this.addEventListener("click", this._boundTagClick);
       this._render();
     }
 
@@ -74,13 +109,15 @@
       if (this._boundClick) this.removeEventListener("click", this._boundClick);
       if (this._boundContextMenu) this.removeEventListener("contextmenu", this._boundContextMenu);
       if (this._boundPinClick) this.removeEventListener("click", this._boundPinClick);
+      if (this._boundTagClick) this.removeEventListener("click", this._boundTagClick);
     }
 
-    setData({ thread, active, timeAgo, esc }) {
+    setData({ thread, active, timeAgo, esc, activeTagFilter = null }) {
       this._thread = thread || null;
       this._active = Boolean(active);
       this._timeAgo = typeof timeAgo === "function" ? timeAgo : null;
       this._esc = typeof esc === "function" ? esc : null;
+      this._activeTagFilter = activeTagFilter ? String(activeTagFilter) : null;
       this._render();
     }
 
@@ -105,6 +142,16 @@
           ${overflowCount > 0 ? `<span class="ti-waiting-agent ti-waiting-agent--count" title="${esc(`${overflowCount} more waiting agents`)}">+${overflowCount}</span>` : ""}
         </div>`
         : "";
+      const tags = Array.isArray(this._thread.tags) ? this._thread.tags : [];
+      const tagsHtml = tags.length
+        ? `<div class="ti-tags" aria-label="Thread tags">${tags
+            .map((tag) => {
+              const label = esc(String(tag || ""));
+              const activeClass = this._activeTagFilter === label ? " is-active" : "";
+              return `<button type="button" class="ti-tag${activeClass}" data-tag="${label}" title="Filter by ${label}">${label}<span class="ti-tag-remove" data-tag="${label}" aria-label="Remove tag ${label}" title="Remove tag">×</span></button>`;
+            })
+            .join("")}</div>`
+        : "";
       this.className = `thread-item${activeClass}`;
       this.id = `ti-${this._thread.id}`;
       this.setAttribute('data-thread-id', String(this._thread.id));
@@ -117,7 +164,8 @@
         <div class="ti-meta">
           <span class="badge badge-${esc(this._thread.status)}">${esc(this._thread.status)}</span>
           <span>${esc(timeAgo(this._thread.created_at))}</span>
-        </div>`;
+        </div>
+        ${tagsHtml}`;
     }
   }
 

--- a/agentchatbus-ts/web-ui/js/shared-sse.js
+++ b/agentchatbus-ts/web-ui/js/shared-sse.js
@@ -72,7 +72,9 @@
         ev.type === "thread.closed" ||
         ev.type === "thread.archived" ||
         ev.type === "thread.unarchived" ||
-        ev.type === "thread.deleted"
+        ev.type === "thread.deleted" ||
+        ev.type === "thread.tag" ||
+        ev.type === "thread.untag"
       ) {
         if (onThreadEvent) {
           await onThreadEvent();

--- a/agentchatbus-ts/web-ui/js/shared-threads.js
+++ b/agentchatbus-ts/web-ui/js/shared-threads.js
@@ -1,5 +1,79 @@
 (function () {
   const PINNED_THREADS_STORAGE_KEY = "acb.pinnedThreads.v1";
+  const THREAD_TAG_PATTERN = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+
+  let activeTagFilter = null;
+  let cachedAllThreads = [];
+
+  function normalizeThreadTagInput(tag) {
+    const normalized = String(tag || "").trim().toLowerCase();
+    if (!normalized || !THREAD_TAG_PATTERN.test(normalized)) {
+      return null;
+    }
+    return normalized;
+  }
+
+  function getActiveTagFilter() {
+    return activeTagFilter;
+  }
+
+  function setActiveTagFilter(tag) {
+    activeTagFilter = tag ? normalizeThreadTagInput(tag) : null;
+    updateTagFilterUI(deriveKnownTags(cachedAllThreads));
+  }
+
+  function clearActiveTagFilter() {
+    setActiveTagFilter(null);
+  }
+
+  function deriveKnownTags(threads) {
+    const tags = new Set();
+    for (const thread of Array.isArray(threads) ? threads : []) {
+      for (const tag of Array.isArray(thread?.tags) ? thread.tags : []) {
+        const normalized = normalizeThreadTagInput(tag);
+        if (normalized) {
+          tags.add(normalized);
+        }
+      }
+    }
+    return Array.from(tags).sort();
+  }
+
+  function updateTagFilterUI(knownTags) {
+    const container = document.getElementById("thread-tag-filter-list");
+    if (!container) return;
+
+    const tags = Array.isArray(knownTags) ? knownTags : [];
+    if (!tags.length && !activeTagFilter) {
+      container.innerHTML = `<div class="thread-tag-filter-empty">No tags yet</div>`;
+      return;
+    }
+
+    const chips = tags
+      .map((tag) => {
+        const activeClass = activeTagFilter === tag ? " is-active" : "";
+        return `<button type="button" class="thread-tag-filter-chip${activeClass}" data-tag="${tag}" onclick="setThreadTagFilter('${tag}')">${tag}</button>`;
+      })
+      .join("");
+
+    const clearButton = activeTagFilter
+      ? `<button type="button" class="thread-tag-filter-clear" onclick="clearThreadTagFilter()">Clear tag filter</button>`
+      : "";
+
+    container.innerHTML = `${chips}${clearButton}`;
+  }
+
+  function filterThreadsForDisplay(allThreads, selectedStatuses, tagFilter) {
+    return (Array.isArray(allThreads) ? allThreads : []).filter((thread) => {
+      if (!selectedStatuses.has(thread.status)) {
+        return false;
+      }
+      if (tagFilter && !(Array.isArray(thread.tags) ? thread.tags : []).includes(tagFilter)) {
+        return false;
+      }
+      return true;
+    });
+  }
 
   function loadPinnedThreadIds() {
     try {
@@ -110,8 +184,11 @@
     onSelectThread,
     onTogglePin,
     onOpenContextMenu,
+    onTagFilter,
+    onTagRemove,
     esc,
     timeAgo,
+    activeTagFilter: activeTag = null,
   }) {
     const pane = document.getElementById("thread-pane");
     if (!pane) return;
@@ -130,6 +207,7 @@
         active: t.id === activeThreadId,
         timeAgo,
         esc,
+        activeTagFilter: activeTag,
       });
       item.addEventListener("thread-select", (e) => {
         const d = e.detail || {};
@@ -150,6 +228,20 @@
           onTogglePin(d.id, d.pinned !== false);
         }
       });
+      item.addEventListener("thread-tag-filter", (e) => {
+        const d = e.detail || {};
+        if (!d.tag || typeof onTagFilter !== "function") {
+          return;
+        }
+        onTagFilter(d.tag);
+      });
+      item.addEventListener("thread-tag-remove", (e) => {
+        const d = e.detail || {};
+        if (!d.id || !d.tag || typeof onTagRemove !== "function") {
+          return;
+        }
+        onTagRemove(d.id, d.tag);
+      });
       pane.appendChild(item);
     });
   }
@@ -163,17 +255,20 @@
     onSelectThread,
     onTogglePin,
     onOpenContextMenu,
+    onTagFilter,
+    onTagRemove,
     esc,
     timeAgo,
     updateThreadFilterButton,
   }) {
     const response = (await api("/api/threads?include_archived=1")) || { threads: [] };
-    const allThreads = sortThreadsForDisplay(decorateThreads((response && response.threads) || []));
+    cachedAllThreads = sortThreadsForDisplay(decorateThreads((response && response.threads) || []));
+    updateTagFilterUI(deriveKnownTags(cachedAllThreads));
     const selectedStatuses = getSelectedStatuses();
     const activeThreadId = getActiveThreadId();
-    const threads = allThreads.filter((t) => selectedStatuses.has(t.status));
+    const threads = filterThreadsForDisplay(cachedAllThreads, selectedStatuses, activeTagFilter);
     if (activeThreadId && typeof onActiveThreadStatus === "function") {
-      const activeThread = allThreads.find((t) => t.id === activeThreadId) || null;
+      const activeThread = cachedAllThreads.find((t) => t.id === activeThreadId) || null;
       onActiveThreadStatus(activeThread ? normalizeThreadStatus(activeThread.status) : null);
     }
 
@@ -188,8 +283,11 @@
       onSelectThread,
       onTogglePin,
       onOpenContextMenu,
+      onTagFilter,
+      onTagRemove,
       esc,
       timeAgo,
+      activeTagFilter,
     });
 
     updateThreadFilterButton();
@@ -525,6 +623,70 @@ Task: After entering, stand by. Human programmers may need to publish requiremen
     return result;
   }
 
+  async function addThreadTag(threadId, tag, api) {
+    const normalized = normalizeThreadTagInput(tag);
+    if (!normalized) {
+      return { ok: false, detail: "Invalid tag: use lowercase letters, numbers, underscore, or hyphen (max 32 chars)." };
+    }
+    return api(`/api/threads/${threadId}/tags`, {
+      method: "POST",
+      body: JSON.stringify({ tag: normalized }),
+    });
+  }
+
+  async function removeThreadTag(threadId, tag, api) {
+    const normalized = normalizeThreadTagInput(tag) || String(tag || "").trim().toLowerCase();
+    if (!normalized) {
+      return { ok: false, detail: "Invalid tag" };
+    }
+    return api(`/api/threads/${threadId}/tags/${encodeURIComponent(normalized)}`, {
+      method: "DELETE",
+    });
+  }
+
+  async function addTagFromMenu({
+    getContextMenuThread,
+    hideThreadContextMenu,
+    api,
+    refreshThreads,
+  }) {
+    const ctx = getContextMenuThread();
+    if (!ctx?.id) return null;
+    const inputDialog = document.getElementById("input-dialog");
+    if (!inputDialog || typeof inputDialog.show !== "function") {
+      console.error("[addTagFromMenu] Input dialog not found");
+      return null;
+    }
+
+    const { id, _clickX = null, _clickY = null } = ctx;
+    hideThreadContextMenu();
+
+    const nextTag = await inputDialog.show({
+      title: "Add Tag",
+      message: "Enter a tag slug (lowercase letters, numbers, underscore, hyphen):",
+      placeholder: "feature-alpha",
+      value: "",
+      confirmText: "Add Tag",
+      x: _clickX,
+      y: _clickY,
+    });
+
+    if (nextTag === null) {
+      return null;
+    }
+
+    const result = await addThreadTag(id, nextTag, api);
+    if (!result || result.ok !== true) {
+      if (result?.detail) {
+        alert(result.detail);
+      }
+      return result || null;
+    }
+
+    await refreshThreads();
+    return result;
+  }
+
   async function pinThreadFromMenu({
     getContextMenuThread,
     hideThreadContextMenu,
@@ -557,5 +719,14 @@ Task: After entering, stand by. Human programmers may need to publish requiremen
     setThreadPinned,
     toggleThreadPinned,
     pinThreadFromMenu,
+    getActiveTagFilter,
+    setActiveTagFilter,
+    clearActiveTagFilter,
+    deriveKnownTags,
+    normalizeThreadTagInput,
+    addThreadTag,
+    removeThreadTag,
+    addTagFromMenu,
+    filterThreadsForDisplay,
   };
 })();

--- a/frontend/src/__tests__/acb-thread-item.test.js
+++ b/frontend/src/__tests__/acb-thread-item.test.js
@@ -58,4 +58,26 @@ describe('acb-thread-item', () => {
     expect(element.innerHTML).not.toContain('🤖');
     expect(element.innerHTML).not.toContain('🧠');
   });
+
+  it('renders tag chips for tagged threads', () => {
+    element.setData({
+      thread: {
+        id: 'thread-3',
+        topic: 'Tagged thread',
+        status: 'discuss',
+        created_at: new Date().toISOString(),
+        isPinned: false,
+        waiting_agents: [],
+        tags: ['feature-alpha', 'docs'],
+      },
+      active: false,
+      timeAgo: () => 'just now',
+      esc: (value) => String(value ?? ''),
+      activeTagFilter: 'docs',
+    });
+
+    const tags = Array.from(element.querySelectorAll('.ti-tag')).map((node) => node.getAttribute('data-tag'));
+    expect(tags).toEqual(['feature-alpha', 'docs']);
+    expect(element.querySelector('.ti-tag.is-active')?.getAttribute('data-tag')).toBe('docs');
+  });
 });

--- a/frontend/src/__tests__/thread-tags.test.js
+++ b/frontend/src/__tests__/thread-tags.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import '../../../web-ui/js/shared-threads.js';
+
+const {
+  normalizeThreadTagInput,
+  deriveKnownTags,
+  filterThreadsForDisplay,
+  setActiveTagFilter,
+  clearActiveTagFilter,
+  getActiveTagFilter,
+} = window.AcbThreads;
+
+describe('thread tag helpers', () => {
+  beforeEach(() => {
+    clearActiveTagFilter();
+  });
+
+  it('normalizeThreadTagInput lowercases and validates slugs', () => {
+    expect(normalizeThreadTagInput(' Feature-Alpha ')).toBe('feature-alpha');
+    expect(normalizeThreadTagInput('bad tag')).toBeNull();
+    expect(normalizeThreadTagInput('')).toBeNull();
+  });
+
+  it('deriveKnownTags collects unique sorted tags', () => {
+    const tags = deriveKnownTags([
+      { id: 't1', tags: ['beta', 'alpha'] },
+      { id: 't2', tags: ['alpha'] },
+      { id: 't3', tags: [] },
+    ]);
+    expect(tags).toEqual(['alpha', 'beta']);
+  });
+
+  it('filterThreadsForDisplay applies status and tag filters together', () => {
+    const selectedStatuses = new Set(['discuss', 'implement']);
+    const threads = [
+      { id: 't1', status: 'discuss', tags: ['alpha'] },
+      { id: 't2', status: 'implement', tags: ['alpha'] },
+      { id: 't3', status: 'discuss', tags: ['beta'] },
+      { id: 't4', status: 'closed', tags: ['alpha'] },
+    ];
+
+    const filtered = filterThreadsForDisplay(threads, selectedStatuses, 'alpha');
+    expect(filtered.map((thread) => thread.id)).toEqual(['t1', 't2']);
+  });
+
+  it('setActiveTagFilter stores normalized active tag', () => {
+    setActiveTagFilter('Docs');
+    expect(getActiveTagFilter()).toBe('docs');
+    clearActiveTagFilter();
+    expect(getActiveTagFilter()).toBeNull();
+  });
+});

--- a/vscode-agentchatbus/resources/web-ui/css/main.css
+++ b/vscode-agentchatbus/resources/web-ui/css/main.css
@@ -1977,6 +1977,105 @@ body[data-theme="light"] .reaction-pill {
   color: #555;
 }
 
+.ti-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.ti-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  padding: 1px 7px;
+  border-radius: 12px;
+  background: rgba(100,100,120,0.12);
+  border: 1px solid rgba(100,100,120,0.22);
+  color: var(--text-secondary, #aaa);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.ti-tag.is-active {
+  background: rgba(59,130,246,0.18);
+  border-color: rgba(59,130,246,0.35);
+  color: var(--text-1, #dbeafe);
+}
+
+.ti-tag-remove {
+  font-size: 12px;
+  line-height: 1;
+  opacity: 0.75;
+  cursor: pointer;
+}
+
+.ti-tag-remove:hover {
+  opacity: 1;
+}
+
+.thread-tag-filter-section {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(120,120,140,0.18);
+}
+
+.thread-tag-filter-title {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-3, #888);
+  margin-bottom: 6px;
+}
+
+.thread-tag-filter-list,
+.thread-tag-filter-empty {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.thread-tag-filter-chip {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  background: rgba(100,100,120,0.12);
+  border: 1px solid rgba(100,100,120,0.22);
+  color: var(--text-secondary, #aaa);
+  cursor: pointer;
+}
+
+.thread-tag-filter-chip.is-active {
+  background: rgba(59,130,246,0.18);
+  border-color: rgba(59,130,246,0.35);
+  color: var(--text-1, #dbeafe);
+}
+
+.thread-tag-filter-clear {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  background: transparent;
+  border: 1px dashed rgba(120,120,140,0.35);
+  color: var(--text-3, #888);
+  cursor: pointer;
+}
+
+body[data-theme="light"] .ti-tag,
+body[data-theme="light"] .thread-tag-filter-chip {
+  background: rgba(0,0,0,0.06);
+  border-color: rgba(0,0,0,0.12);
+  color: #555;
+}
+
+body[data-theme="light"] .ti-tag.is-active,
+body[data-theme="light"] .thread-tag-filter-chip.is-active {
+  background: rgba(37,99,235,0.12);
+  border-color: rgba(37,99,235,0.28);
+  color: #1d4ed8;
+}
+
 body[data-theme="light"] .handoff-badge {
   background: rgba(59,130,246,0.10);
   color: #2563eb;

--- a/vscode-agentchatbus/resources/web-ui/index.html
+++ b/vscode-agentchatbus/resources/web-ui/index.html
@@ -1098,6 +1098,14 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
           await refreshThreads();
         },
         onOpenContextMenu: openThreadContextMenu,
+        onTagFilter: async (tag) => {
+          window.AcbThreads.setActiveTagFilter(tag);
+          await refreshThreads();
+        },
+        onTagRemove: async (threadId, tag) => {
+          await window.AcbThreads.removeThreadTag(threadId, tag, api);
+          await refreshThreads();
+        },
         esc,
         timeAgo,
         updateThreadFilterButton,
@@ -1156,6 +1164,25 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
         NORMAL_THREAD_STATUSES,
         selectedThreadStatuses
       );
+    }
+
+    function setThreadTagFilter(tag) {
+      window.AcbThreads.setActiveTagFilter(tag);
+      refreshThreads();
+    }
+
+    function clearThreadTagFilter() {
+      window.AcbThreads.clearActiveTagFilter();
+      refreshThreads();
+    }
+
+    async function addTagFromMenu() {
+      return window.AcbThreads.addTagFromMenu({
+        getContextMenuThread: () => contextMenuThread,
+        hideThreadContextMenu,
+        api,
+        refreshThreads,
+      });
     }
 
     async function selectThread(id, topic, status, initialSyncContext = null) {

--- a/vscode-agentchatbus/resources/web-ui/js/components/acb-thread-context-menu.js
+++ b/vscode-agentchatbus/resources/web-ui/js/components/acb-thread-context-menu.js
@@ -8,6 +8,7 @@
           <button id="ctx-copy-name" class="ctx-item" type="button" role="menuitem" onclick="copyThreadNameFromMenu()">🧵 Copy Thread Name</button>
           <hr class="ctx-divider" aria-hidden="true">
           <button id="ctx-rename" class="ctx-item" type="button" role="menuitem" onclick="renameThreadFromMenu()">✏️ Rename</button>
+          <button id="ctx-add-tag" class="ctx-item" type="button" role="menuitem" onclick="addTagFromMenu()">🏷️ Add tag…</button>
           <button id="ctx-close" class="ctx-item" type="button" role="menuitem" onclick="closeThreadFromMenu()">🔒 Close</button>
           <button id="ctx-archive" class="ctx-item" type="button" role="menuitem" onclick="archiveThreadFromMenu()">🗄️ Archive</button>
           <button id="ctx-unarchive" class="ctx-item" type="button" role="menuitem" onclick="unarchiveThreadFromMenu()" style="display: none;">📂 Unarchive</button>

--- a/vscode-agentchatbus/resources/web-ui/js/components/acb-thread-filter-shell.js
+++ b/vscode-agentchatbus/resources/web-ui/js/components/acb-thread-filter-shell.js
@@ -14,6 +14,10 @@
             <acb-filter-row status="done" checked></acb-filter-row>
             <acb-filter-row status="closed" checked></acb-filter-row>
             <acb-filter-row status="archived"></acb-filter-row>
+            <div class="thread-tag-filter-section">
+              <div class="thread-tag-filter-title">Tags</div>
+              <div id="thread-tag-filter-list" class="thread-tag-filter-list"></div>
+            </div>
           </div>
         </div>`;
     }

--- a/vscode-agentchatbus/resources/web-ui/js/components/acb-thread-item.js
+++ b/vscode-agentchatbus/resources/web-ui/js/components/acb-thread-item.js
@@ -9,6 +9,7 @@
       this._boundClick = null;
       this._boundContextMenu = null;
       this._boundPinClick = null;
+      this._boundTagClick = null;
     }
 
     connectedCallback() {
@@ -64,9 +65,43 @@
         };
       }
 
+      if (!this._boundTagClick) {
+        this._boundTagClick = (e) => {
+          const removeBtn = e.target.closest(".ti-tag-remove");
+          if (removeBtn) {
+            e.preventDefault();
+            e.stopPropagation();
+            if (!this._thread) return;
+            this.dispatchEvent(
+              new CustomEvent("thread-tag-remove", {
+                bubbles: true,
+                detail: {
+                  id: this._thread.id,
+                  tag: removeBtn.getAttribute("data-tag") || "",
+                },
+              })
+            );
+            return;
+          }
+          const tagBtn = e.target.closest(".ti-tag");
+          if (!tagBtn || !this._thread) return;
+          e.preventDefault();
+          e.stopPropagation();
+          this.dispatchEvent(
+            new CustomEvent("thread-tag-filter", {
+              bubbles: true,
+              detail: {
+                tag: tagBtn.getAttribute("data-tag") || "",
+              },
+            })
+          );
+        };
+      }
+
       this.addEventListener("click", this._boundClick);
       this.addEventListener("contextmenu", this._boundContextMenu);
       this.addEventListener("click", this._boundPinClick);
+      this.addEventListener("click", this._boundTagClick);
       this._render();
     }
 
@@ -74,13 +109,15 @@
       if (this._boundClick) this.removeEventListener("click", this._boundClick);
       if (this._boundContextMenu) this.removeEventListener("contextmenu", this._boundContextMenu);
       if (this._boundPinClick) this.removeEventListener("click", this._boundPinClick);
+      if (this._boundTagClick) this.removeEventListener("click", this._boundTagClick);
     }
 
-    setData({ thread, active, timeAgo, esc }) {
+    setData({ thread, active, timeAgo, esc, activeTagFilter = null }) {
       this._thread = thread || null;
       this._active = Boolean(active);
       this._timeAgo = typeof timeAgo === "function" ? timeAgo : null;
       this._esc = typeof esc === "function" ? esc : null;
+      this._activeTagFilter = activeTagFilter ? String(activeTagFilter) : null;
       this._render();
     }
 
@@ -105,6 +142,16 @@
           ${overflowCount > 0 ? `<span class="ti-waiting-agent ti-waiting-agent--count" title="${esc(`${overflowCount} more waiting agents`)}">+${overflowCount}</span>` : ""}
         </div>`
         : "";
+      const tags = Array.isArray(this._thread.tags) ? this._thread.tags : [];
+      const tagsHtml = tags.length
+        ? `<div class="ti-tags" aria-label="Thread tags">${tags
+            .map((tag) => {
+              const label = esc(String(tag || ""));
+              const activeClass = this._activeTagFilter === label ? " is-active" : "";
+              return `<button type="button" class="ti-tag${activeClass}" data-tag="${label}" title="Filter by ${label}">${label}<span class="ti-tag-remove" data-tag="${label}" aria-label="Remove tag ${label}" title="Remove tag">×</span></button>`;
+            })
+            .join("")}</div>`
+        : "";
       this.className = `thread-item${activeClass}`;
       this.id = `ti-${this._thread.id}`;
       this.setAttribute('data-thread-id', String(this._thread.id));
@@ -117,7 +164,8 @@
         <div class="ti-meta">
           <span class="badge badge-${esc(this._thread.status)}">${esc(this._thread.status)}</span>
           <span>${esc(timeAgo(this._thread.created_at))}</span>
-        </div>`;
+        </div>
+        ${tagsHtml}`;
     }
   }
 

--- a/vscode-agentchatbus/resources/web-ui/js/shared-sse.js
+++ b/vscode-agentchatbus/resources/web-ui/js/shared-sse.js
@@ -72,7 +72,9 @@
         ev.type === "thread.closed" ||
         ev.type === "thread.archived" ||
         ev.type === "thread.unarchived" ||
-        ev.type === "thread.deleted"
+        ev.type === "thread.deleted" ||
+        ev.type === "thread.tag" ||
+        ev.type === "thread.untag"
       ) {
         if (onThreadEvent) {
           await onThreadEvent();

--- a/vscode-agentchatbus/resources/web-ui/js/shared-threads.js
+++ b/vscode-agentchatbus/resources/web-ui/js/shared-threads.js
@@ -1,5 +1,79 @@
 (function () {
   const PINNED_THREADS_STORAGE_KEY = "acb.pinnedThreads.v1";
+  const THREAD_TAG_PATTERN = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+
+  let activeTagFilter = null;
+  let cachedAllThreads = [];
+
+  function normalizeThreadTagInput(tag) {
+    const normalized = String(tag || "").trim().toLowerCase();
+    if (!normalized || !THREAD_TAG_PATTERN.test(normalized)) {
+      return null;
+    }
+    return normalized;
+  }
+
+  function getActiveTagFilter() {
+    return activeTagFilter;
+  }
+
+  function setActiveTagFilter(tag) {
+    activeTagFilter = tag ? normalizeThreadTagInput(tag) : null;
+    updateTagFilterUI(deriveKnownTags(cachedAllThreads));
+  }
+
+  function clearActiveTagFilter() {
+    setActiveTagFilter(null);
+  }
+
+  function deriveKnownTags(threads) {
+    const tags = new Set();
+    for (const thread of Array.isArray(threads) ? threads : []) {
+      for (const tag of Array.isArray(thread?.tags) ? thread.tags : []) {
+        const normalized = normalizeThreadTagInput(tag);
+        if (normalized) {
+          tags.add(normalized);
+        }
+      }
+    }
+    return Array.from(tags).sort();
+  }
+
+  function updateTagFilterUI(knownTags) {
+    const container = document.getElementById("thread-tag-filter-list");
+    if (!container) return;
+
+    const tags = Array.isArray(knownTags) ? knownTags : [];
+    if (!tags.length && !activeTagFilter) {
+      container.innerHTML = `<div class="thread-tag-filter-empty">No tags yet</div>`;
+      return;
+    }
+
+    const chips = tags
+      .map((tag) => {
+        const activeClass = activeTagFilter === tag ? " is-active" : "";
+        return `<button type="button" class="thread-tag-filter-chip${activeClass}" data-tag="${tag}" onclick="setThreadTagFilter('${tag}')">${tag}</button>`;
+      })
+      .join("");
+
+    const clearButton = activeTagFilter
+      ? `<button type="button" class="thread-tag-filter-clear" onclick="clearThreadTagFilter()">Clear tag filter</button>`
+      : "";
+
+    container.innerHTML = `${chips}${clearButton}`;
+  }
+
+  function filterThreadsForDisplay(allThreads, selectedStatuses, tagFilter) {
+    return (Array.isArray(allThreads) ? allThreads : []).filter((thread) => {
+      if (!selectedStatuses.has(thread.status)) {
+        return false;
+      }
+      if (tagFilter && !(Array.isArray(thread.tags) ? thread.tags : []).includes(tagFilter)) {
+        return false;
+      }
+      return true;
+    });
+  }
 
   function loadPinnedThreadIds() {
     try {
@@ -110,8 +184,11 @@
     onSelectThread,
     onTogglePin,
     onOpenContextMenu,
+    onTagFilter,
+    onTagRemove,
     esc,
     timeAgo,
+    activeTagFilter: activeTag = null,
   }) {
     const pane = document.getElementById("thread-pane");
     if (!pane) return;
@@ -130,6 +207,7 @@
         active: t.id === activeThreadId,
         timeAgo,
         esc,
+        activeTagFilter: activeTag,
       });
       item.addEventListener("thread-select", (e) => {
         const d = e.detail || {};
@@ -150,6 +228,20 @@
           onTogglePin(d.id, d.pinned !== false);
         }
       });
+      item.addEventListener("thread-tag-filter", (e) => {
+        const d = e.detail || {};
+        if (!d.tag || typeof onTagFilter !== "function") {
+          return;
+        }
+        onTagFilter(d.tag);
+      });
+      item.addEventListener("thread-tag-remove", (e) => {
+        const d = e.detail || {};
+        if (!d.id || !d.tag || typeof onTagRemove !== "function") {
+          return;
+        }
+        onTagRemove(d.id, d.tag);
+      });
       pane.appendChild(item);
     });
   }
@@ -163,17 +255,20 @@
     onSelectThread,
     onTogglePin,
     onOpenContextMenu,
+    onTagFilter,
+    onTagRemove,
     esc,
     timeAgo,
     updateThreadFilterButton,
   }) {
     const response = (await api("/api/threads?include_archived=1")) || { threads: [] };
-    const allThreads = sortThreadsForDisplay(decorateThreads((response && response.threads) || []));
+    cachedAllThreads = sortThreadsForDisplay(decorateThreads((response && response.threads) || []));
+    updateTagFilterUI(deriveKnownTags(cachedAllThreads));
     const selectedStatuses = getSelectedStatuses();
     const activeThreadId = getActiveThreadId();
-    const threads = allThreads.filter((t) => selectedStatuses.has(t.status));
+    const threads = filterThreadsForDisplay(cachedAllThreads, selectedStatuses, activeTagFilter);
     if (activeThreadId && typeof onActiveThreadStatus === "function") {
-      const activeThread = allThreads.find((t) => t.id === activeThreadId) || null;
+      const activeThread = cachedAllThreads.find((t) => t.id === activeThreadId) || null;
       onActiveThreadStatus(activeThread ? normalizeThreadStatus(activeThread.status) : null);
     }
 
@@ -188,8 +283,11 @@
       onSelectThread,
       onTogglePin,
       onOpenContextMenu,
+      onTagFilter,
+      onTagRemove,
       esc,
       timeAgo,
+      activeTagFilter,
     });
 
     updateThreadFilterButton();
@@ -525,6 +623,70 @@ Task: After entering, stand by. Human programmers may need to publish requiremen
     return result;
   }
 
+  async function addThreadTag(threadId, tag, api) {
+    const normalized = normalizeThreadTagInput(tag);
+    if (!normalized) {
+      return { ok: false, detail: "Invalid tag: use lowercase letters, numbers, underscore, or hyphen (max 32 chars)." };
+    }
+    return api(`/api/threads/${threadId}/tags`, {
+      method: "POST",
+      body: JSON.stringify({ tag: normalized }),
+    });
+  }
+
+  async function removeThreadTag(threadId, tag, api) {
+    const normalized = normalizeThreadTagInput(tag) || String(tag || "").trim().toLowerCase();
+    if (!normalized) {
+      return { ok: false, detail: "Invalid tag" };
+    }
+    return api(`/api/threads/${threadId}/tags/${encodeURIComponent(normalized)}`, {
+      method: "DELETE",
+    });
+  }
+
+  async function addTagFromMenu({
+    getContextMenuThread,
+    hideThreadContextMenu,
+    api,
+    refreshThreads,
+  }) {
+    const ctx = getContextMenuThread();
+    if (!ctx?.id) return null;
+    const inputDialog = document.getElementById("input-dialog");
+    if (!inputDialog || typeof inputDialog.show !== "function") {
+      console.error("[addTagFromMenu] Input dialog not found");
+      return null;
+    }
+
+    const { id, _clickX = null, _clickY = null } = ctx;
+    hideThreadContextMenu();
+
+    const nextTag = await inputDialog.show({
+      title: "Add Tag",
+      message: "Enter a tag slug (lowercase letters, numbers, underscore, hyphen):",
+      placeholder: "feature-alpha",
+      value: "",
+      confirmText: "Add Tag",
+      x: _clickX,
+      y: _clickY,
+    });
+
+    if (nextTag === null) {
+      return null;
+    }
+
+    const result = await addThreadTag(id, nextTag, api);
+    if (!result || result.ok !== true) {
+      if (result?.detail) {
+        alert(result.detail);
+      }
+      return result || null;
+    }
+
+    await refreshThreads();
+    return result;
+  }
+
   async function pinThreadFromMenu({
     getContextMenuThread,
     hideThreadContextMenu,
@@ -557,5 +719,14 @@ Task: After entering, stand by. Human programmers may need to publish requiremen
     setThreadPinned,
     toggleThreadPinned,
     pinThreadFromMenu,
+    getActiveTagFilter,
+    setActiveTagFilter,
+    clearActiveTagFilter,
+    deriveKnownTags,
+    normalizeThreadTagInput,
+    addThreadTag,
+    removeThreadTag,
+    addTagFromMenu,
+    filterThreadsForDisplay,
   };
 })();

--- a/web-ui/css/main.css
+++ b/web-ui/css/main.css
@@ -1977,6 +1977,105 @@ body[data-theme="light"] .reaction-pill {
   color: #555;
 }
 
+.ti-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.ti-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  padding: 1px 7px;
+  border-radius: 12px;
+  background: rgba(100,100,120,0.12);
+  border: 1px solid rgba(100,100,120,0.22);
+  color: var(--text-secondary, #aaa);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.ti-tag.is-active {
+  background: rgba(59,130,246,0.18);
+  border-color: rgba(59,130,246,0.35);
+  color: var(--text-1, #dbeafe);
+}
+
+.ti-tag-remove {
+  font-size: 12px;
+  line-height: 1;
+  opacity: 0.75;
+  cursor: pointer;
+}
+
+.ti-tag-remove:hover {
+  opacity: 1;
+}
+
+.thread-tag-filter-section {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(120,120,140,0.18);
+}
+
+.thread-tag-filter-title {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-3, #888);
+  margin-bottom: 6px;
+}
+
+.thread-tag-filter-list,
+.thread-tag-filter-empty {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.thread-tag-filter-chip {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  background: rgba(100,100,120,0.12);
+  border: 1px solid rgba(100,100,120,0.22);
+  color: var(--text-secondary, #aaa);
+  cursor: pointer;
+}
+
+.thread-tag-filter-chip.is-active {
+  background: rgba(59,130,246,0.18);
+  border-color: rgba(59,130,246,0.35);
+  color: var(--text-1, #dbeafe);
+}
+
+.thread-tag-filter-clear {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  background: transparent;
+  border: 1px dashed rgba(120,120,140,0.35);
+  color: var(--text-3, #888);
+  cursor: pointer;
+}
+
+body[data-theme="light"] .ti-tag,
+body[data-theme="light"] .thread-tag-filter-chip {
+  background: rgba(0,0,0,0.06);
+  border-color: rgba(0,0,0,0.12);
+  color: #555;
+}
+
+body[data-theme="light"] .ti-tag.is-active,
+body[data-theme="light"] .thread-tag-filter-chip.is-active {
+  background: rgba(37,99,235,0.12);
+  border-color: rgba(37,99,235,0.28);
+  color: #1d4ed8;
+}
+
 body[data-theme="light"] .handoff-badge {
   background: rgba(59,130,246,0.10);
   color: #2563eb;

--- a/web-ui/index.html
+++ b/web-ui/index.html
@@ -1098,6 +1098,14 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
           await refreshThreads();
         },
         onOpenContextMenu: openThreadContextMenu,
+        onTagFilter: async (tag) => {
+          window.AcbThreads.setActiveTagFilter(tag);
+          await refreshThreads();
+        },
+        onTagRemove: async (threadId, tag) => {
+          await window.AcbThreads.removeThreadTag(threadId, tag, api);
+          await refreshThreads();
+        },
         esc,
         timeAgo,
         updateThreadFilterButton,
@@ -1156,6 +1164,25 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
         NORMAL_THREAD_STATUSES,
         selectedThreadStatuses
       );
+    }
+
+    function setThreadTagFilter(tag) {
+      window.AcbThreads.setActiveTagFilter(tag);
+      refreshThreads();
+    }
+
+    function clearThreadTagFilter() {
+      window.AcbThreads.clearActiveTagFilter();
+      refreshThreads();
+    }
+
+    async function addTagFromMenu() {
+      return window.AcbThreads.addTagFromMenu({
+        getContextMenuThread: () => contextMenuThread,
+        hideThreadContextMenu,
+        api,
+        refreshThreads,
+      });
     }
 
     async function selectThread(id, topic, status, initialSyncContext = null) {

--- a/web-ui/js/components/acb-thread-context-menu.js
+++ b/web-ui/js/components/acb-thread-context-menu.js
@@ -8,6 +8,7 @@
           <button id="ctx-copy-name" class="ctx-item" type="button" role="menuitem" onclick="copyThreadNameFromMenu()">🧵 Copy Thread Name</button>
           <hr class="ctx-divider" aria-hidden="true">
           <button id="ctx-rename" class="ctx-item" type="button" role="menuitem" onclick="renameThreadFromMenu()">✏️ Rename</button>
+          <button id="ctx-add-tag" class="ctx-item" type="button" role="menuitem" onclick="addTagFromMenu()">🏷️ Add tag…</button>
           <button id="ctx-close" class="ctx-item" type="button" role="menuitem" onclick="closeThreadFromMenu()">🔒 Close</button>
           <button id="ctx-archive" class="ctx-item" type="button" role="menuitem" onclick="archiveThreadFromMenu()">🗄️ Archive</button>
           <button id="ctx-unarchive" class="ctx-item" type="button" role="menuitem" onclick="unarchiveThreadFromMenu()" style="display: none;">📂 Unarchive</button>

--- a/web-ui/js/components/acb-thread-filter-shell.js
+++ b/web-ui/js/components/acb-thread-filter-shell.js
@@ -14,6 +14,10 @@
             <acb-filter-row status="done" checked></acb-filter-row>
             <acb-filter-row status="closed" checked></acb-filter-row>
             <acb-filter-row status="archived"></acb-filter-row>
+            <div class="thread-tag-filter-section">
+              <div class="thread-tag-filter-title">Tags</div>
+              <div id="thread-tag-filter-list" class="thread-tag-filter-list"></div>
+            </div>
           </div>
         </div>`;
     }

--- a/web-ui/js/components/acb-thread-item.js
+++ b/web-ui/js/components/acb-thread-item.js
@@ -9,6 +9,7 @@
       this._boundClick = null;
       this._boundContextMenu = null;
       this._boundPinClick = null;
+      this._boundTagClick = null;
     }
 
     connectedCallback() {
@@ -64,9 +65,43 @@
         };
       }
 
+      if (!this._boundTagClick) {
+        this._boundTagClick = (e) => {
+          const removeBtn = e.target.closest(".ti-tag-remove");
+          if (removeBtn) {
+            e.preventDefault();
+            e.stopPropagation();
+            if (!this._thread) return;
+            this.dispatchEvent(
+              new CustomEvent("thread-tag-remove", {
+                bubbles: true,
+                detail: {
+                  id: this._thread.id,
+                  tag: removeBtn.getAttribute("data-tag") || "",
+                },
+              })
+            );
+            return;
+          }
+          const tagBtn = e.target.closest(".ti-tag");
+          if (!tagBtn || !this._thread) return;
+          e.preventDefault();
+          e.stopPropagation();
+          this.dispatchEvent(
+            new CustomEvent("thread-tag-filter", {
+              bubbles: true,
+              detail: {
+                tag: tagBtn.getAttribute("data-tag") || "",
+              },
+            })
+          );
+        };
+      }
+
       this.addEventListener("click", this._boundClick);
       this.addEventListener("contextmenu", this._boundContextMenu);
       this.addEventListener("click", this._boundPinClick);
+      this.addEventListener("click", this._boundTagClick);
       this._render();
     }
 
@@ -74,13 +109,15 @@
       if (this._boundClick) this.removeEventListener("click", this._boundClick);
       if (this._boundContextMenu) this.removeEventListener("contextmenu", this._boundContextMenu);
       if (this._boundPinClick) this.removeEventListener("click", this._boundPinClick);
+      if (this._boundTagClick) this.removeEventListener("click", this._boundTagClick);
     }
 
-    setData({ thread, active, timeAgo, esc }) {
+    setData({ thread, active, timeAgo, esc, activeTagFilter = null }) {
       this._thread = thread || null;
       this._active = Boolean(active);
       this._timeAgo = typeof timeAgo === "function" ? timeAgo : null;
       this._esc = typeof esc === "function" ? esc : null;
+      this._activeTagFilter = activeTagFilter ? String(activeTagFilter) : null;
       this._render();
     }
 
@@ -105,6 +142,16 @@
           ${overflowCount > 0 ? `<span class="ti-waiting-agent ti-waiting-agent--count" title="${esc(`${overflowCount} more waiting agents`)}">+${overflowCount}</span>` : ""}
         </div>`
         : "";
+      const tags = Array.isArray(this._thread.tags) ? this._thread.tags : [];
+      const tagsHtml = tags.length
+        ? `<div class="ti-tags" aria-label="Thread tags">${tags
+            .map((tag) => {
+              const label = esc(String(tag || ""));
+              const activeClass = this._activeTagFilter === label ? " is-active" : "";
+              return `<button type="button" class="ti-tag${activeClass}" data-tag="${label}" title="Filter by ${label}">${label}<span class="ti-tag-remove" data-tag="${label}" aria-label="Remove tag ${label}" title="Remove tag">×</span></button>`;
+            })
+            .join("")}</div>`
+        : "";
       this.className = `thread-item${activeClass}`;
       this.id = `ti-${this._thread.id}`;
       this.setAttribute('data-thread-id', String(this._thread.id));
@@ -117,7 +164,8 @@
         <div class="ti-meta">
           <span class="badge badge-${esc(this._thread.status)}">${esc(this._thread.status)}</span>
           <span>${esc(timeAgo(this._thread.created_at))}</span>
-        </div>`;
+        </div>
+        ${tagsHtml}`;
     }
   }
 

--- a/web-ui/js/shared-sse.js
+++ b/web-ui/js/shared-sse.js
@@ -72,7 +72,9 @@
         ev.type === "thread.closed" ||
         ev.type === "thread.archived" ||
         ev.type === "thread.unarchived" ||
-        ev.type === "thread.deleted"
+        ev.type === "thread.deleted" ||
+        ev.type === "thread.tag" ||
+        ev.type === "thread.untag"
       ) {
         if (onThreadEvent) {
           await onThreadEvent();

--- a/web-ui/js/shared-threads.js
+++ b/web-ui/js/shared-threads.js
@@ -1,5 +1,79 @@
 (function () {
   const PINNED_THREADS_STORAGE_KEY = "acb.pinnedThreads.v1";
+  const THREAD_TAG_PATTERN = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+
+  let activeTagFilter = null;
+  let cachedAllThreads = [];
+
+  function normalizeThreadTagInput(tag) {
+    const normalized = String(tag || "").trim().toLowerCase();
+    if (!normalized || !THREAD_TAG_PATTERN.test(normalized)) {
+      return null;
+    }
+    return normalized;
+  }
+
+  function getActiveTagFilter() {
+    return activeTagFilter;
+  }
+
+  function setActiveTagFilter(tag) {
+    activeTagFilter = tag ? normalizeThreadTagInput(tag) : null;
+    updateTagFilterUI(deriveKnownTags(cachedAllThreads));
+  }
+
+  function clearActiveTagFilter() {
+    setActiveTagFilter(null);
+  }
+
+  function deriveKnownTags(threads) {
+    const tags = new Set();
+    for (const thread of Array.isArray(threads) ? threads : []) {
+      for (const tag of Array.isArray(thread?.tags) ? thread.tags : []) {
+        const normalized = normalizeThreadTagInput(tag);
+        if (normalized) {
+          tags.add(normalized);
+        }
+      }
+    }
+    return Array.from(tags).sort();
+  }
+
+  function updateTagFilterUI(knownTags) {
+    const container = document.getElementById("thread-tag-filter-list");
+    if (!container) return;
+
+    const tags = Array.isArray(knownTags) ? knownTags : [];
+    if (!tags.length && !activeTagFilter) {
+      container.innerHTML = `<div class="thread-tag-filter-empty">No tags yet</div>`;
+      return;
+    }
+
+    const chips = tags
+      .map((tag) => {
+        const activeClass = activeTagFilter === tag ? " is-active" : "";
+        return `<button type="button" class="thread-tag-filter-chip${activeClass}" data-tag="${tag}" onclick="setThreadTagFilter('${tag}')">${tag}</button>`;
+      })
+      .join("");
+
+    const clearButton = activeTagFilter
+      ? `<button type="button" class="thread-tag-filter-clear" onclick="clearThreadTagFilter()">Clear tag filter</button>`
+      : "";
+
+    container.innerHTML = `${chips}${clearButton}`;
+  }
+
+  function filterThreadsForDisplay(allThreads, selectedStatuses, tagFilter) {
+    return (Array.isArray(allThreads) ? allThreads : []).filter((thread) => {
+      if (!selectedStatuses.has(thread.status)) {
+        return false;
+      }
+      if (tagFilter && !(Array.isArray(thread.tags) ? thread.tags : []).includes(tagFilter)) {
+        return false;
+      }
+      return true;
+    });
+  }
 
   function loadPinnedThreadIds() {
     try {
@@ -110,8 +184,11 @@
     onSelectThread,
     onTogglePin,
     onOpenContextMenu,
+    onTagFilter,
+    onTagRemove,
     esc,
     timeAgo,
+    activeTagFilter: activeTag = null,
   }) {
     const pane = document.getElementById("thread-pane");
     if (!pane) return;
@@ -130,6 +207,7 @@
         active: t.id === activeThreadId,
         timeAgo,
         esc,
+        activeTagFilter: activeTag,
       });
       item.addEventListener("thread-select", (e) => {
         const d = e.detail || {};
@@ -150,6 +228,20 @@
           onTogglePin(d.id, d.pinned !== false);
         }
       });
+      item.addEventListener("thread-tag-filter", (e) => {
+        const d = e.detail || {};
+        if (!d.tag || typeof onTagFilter !== "function") {
+          return;
+        }
+        onTagFilter(d.tag);
+      });
+      item.addEventListener("thread-tag-remove", (e) => {
+        const d = e.detail || {};
+        if (!d.id || !d.tag || typeof onTagRemove !== "function") {
+          return;
+        }
+        onTagRemove(d.id, d.tag);
+      });
       pane.appendChild(item);
     });
   }
@@ -163,17 +255,20 @@
     onSelectThread,
     onTogglePin,
     onOpenContextMenu,
+    onTagFilter,
+    onTagRemove,
     esc,
     timeAgo,
     updateThreadFilterButton,
   }) {
     const response = (await api("/api/threads?include_archived=1")) || { threads: [] };
-    const allThreads = sortThreadsForDisplay(decorateThreads((response && response.threads) || []));
+    cachedAllThreads = sortThreadsForDisplay(decorateThreads((response && response.threads) || []));
+    updateTagFilterUI(deriveKnownTags(cachedAllThreads));
     const selectedStatuses = getSelectedStatuses();
     const activeThreadId = getActiveThreadId();
-    const threads = allThreads.filter((t) => selectedStatuses.has(t.status));
+    const threads = filterThreadsForDisplay(cachedAllThreads, selectedStatuses, activeTagFilter);
     if (activeThreadId && typeof onActiveThreadStatus === "function") {
-      const activeThread = allThreads.find((t) => t.id === activeThreadId) || null;
+      const activeThread = cachedAllThreads.find((t) => t.id === activeThreadId) || null;
       onActiveThreadStatus(activeThread ? normalizeThreadStatus(activeThread.status) : null);
     }
 
@@ -188,8 +283,11 @@
       onSelectThread,
       onTogglePin,
       onOpenContextMenu,
+      onTagFilter,
+      onTagRemove,
       esc,
       timeAgo,
+      activeTagFilter,
     });
 
     updateThreadFilterButton();
@@ -525,6 +623,70 @@ Task: After entering, stand by. Human programmers may need to publish requiremen
     return result;
   }
 
+  async function addThreadTag(threadId, tag, api) {
+    const normalized = normalizeThreadTagInput(tag);
+    if (!normalized) {
+      return { ok: false, detail: "Invalid tag: use lowercase letters, numbers, underscore, or hyphen (max 32 chars)." };
+    }
+    return api(`/api/threads/${threadId}/tags`, {
+      method: "POST",
+      body: JSON.stringify({ tag: normalized }),
+    });
+  }
+
+  async function removeThreadTag(threadId, tag, api) {
+    const normalized = normalizeThreadTagInput(tag) || String(tag || "").trim().toLowerCase();
+    if (!normalized) {
+      return { ok: false, detail: "Invalid tag" };
+    }
+    return api(`/api/threads/${threadId}/tags/${encodeURIComponent(normalized)}`, {
+      method: "DELETE",
+    });
+  }
+
+  async function addTagFromMenu({
+    getContextMenuThread,
+    hideThreadContextMenu,
+    api,
+    refreshThreads,
+  }) {
+    const ctx = getContextMenuThread();
+    if (!ctx?.id) return null;
+    const inputDialog = document.getElementById("input-dialog");
+    if (!inputDialog || typeof inputDialog.show !== "function") {
+      console.error("[addTagFromMenu] Input dialog not found");
+      return null;
+    }
+
+    const { id, _clickX = null, _clickY = null } = ctx;
+    hideThreadContextMenu();
+
+    const nextTag = await inputDialog.show({
+      title: "Add Tag",
+      message: "Enter a tag slug (lowercase letters, numbers, underscore, hyphen):",
+      placeholder: "feature-alpha",
+      value: "",
+      confirmText: "Add Tag",
+      x: _clickX,
+      y: _clickY,
+    });
+
+    if (nextTag === null) {
+      return null;
+    }
+
+    const result = await addThreadTag(id, nextTag, api);
+    if (!result || result.ok !== true) {
+      if (result?.detail) {
+        alert(result.detail);
+      }
+      return result || null;
+    }
+
+    await refreshThreads();
+    return result;
+  }
+
   async function pinThreadFromMenu({
     getContextMenuThread,
     hideThreadContextMenu,
@@ -557,5 +719,14 @@ Task: After entering, stand by. Human programmers may need to publish requiremen
     setThreadPinned,
     toggleThreadPinned,
     pinThreadFromMenu,
+    getActiveTagFilter,
+    setActiveTagFilter,
+    clearActiveTagFilter,
+    deriveKnownTags,
+    normalizeThreadTagInput,
+    addThreadTag,
+    removeThreadTag,
+    addTagFromMenu,
+    filterThreadsForDisplay,
   };
 })();


### PR DESCRIPTION
## Summary
- Add generic thread tagging: SQLite `thread_tags` table, MemoryStore CRUD with slug normalization (`[a-z0-9][a-z0-9_-]{0,31}`), cascade delete on thread removal.
- REST: `GET/POST/DELETE /api/threads/:id/tags`, optional `?tag=` filter on `GET /api/threads`.
- MCP: `thread_tag`, `thread_untag`, `thread_tags_list` (requires `thread_id`); `tags` on `thread_list` / `thread_get`.
- SSE: `thread.tag` / `thread.untag` events.
- Copy tags when restarting a thread (alongside existing settings copy).
- Web UI: tag chips on thread cards, sidebar tag filter (client-side from loaded threads), context menu "Add tag…"; synced to `agentchatbus-ts/web-ui` and VS Code extension bundle.

## Context
Implements UP-27 (backend) + UI-10 (web UI) as a single PR, same bundling pattern as reactions + priority (#29).

## Test plan
- [x] `vitest run tests/unit/test_thread_tags.test.ts` — 9/9 pass
- [x] `vitest run tests/integration/httpServer.test.ts` — 26/26 pass (includes REST tag CRUD, `?tag=` list filter, MCP `thread_tag` dispatch)
- [x] `vitest run frontend/src/__tests__/acb-thread-item.test.js frontend/src/__tests__/thread-tags.test.js` — 7/7 pass
- [x] `npm run sync:webui` + `npm run sync:webui-assets` — bundles aligned with root `web-ui/`
