### PR TITLE
feat(metrics): HTTP request latency p50/p95/p99 per route

### DIFF
--- a/agentchatbus-ts/package-lock.json
+++ b/agentchatbus-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentchatbus-ts",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentchatbus-ts",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "@fastify/multipart": "^9.0.3",
         "@fastify/static": "^9.0.0",

--- a/agentchatbus-ts/package.json
+++ b/agentchatbus-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentchatbus-ts",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "private": true,
   "description": "Initial TypeScript backend workspace for AgentChatBus",
   "type": "module",

--- a/agentchatbus-ts/src/core/config/env.ts
+++ b/agentchatbus-ts/src/core/config/env.ts
@@ -29,7 +29,7 @@ export {
 import { getConfig } from "./registry.js";
 import type { AppConfig } from "./registry.js";
 
-export const BUS_VERSION = "0.2.29";
+export const BUS_VERSION = "0.2.30";
 export const ADMIN_TOKEN: string | null = getConfig().adminToken;
 export const ENABLE_HANDOFF_TARGET = getConfig().enableHandoffTarget;
 export const ENABLE_STOP_REASON = getConfig().enableStopReason;

--- a/agentchatbus-ts/src/transports/http/httpLatencyTracker.ts
+++ b/agentchatbus-ts/src/transports/http/httpLatencyTracker.ts
@@ -1,0 +1,184 @@
+export const DEFAULT_WINDOW_MS = 15 * 60 * 1000;
+export const DEFAULT_MAX_ROUTES = 64;
+export const DEFAULT_MAX_SAMPLES_PER_ROUTE = 256;
+export const EXCLUDED_PREFIXES = ["/static/", "/favicon.ico"];
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const LONG_HEX_PATTERN = /^[0-9a-f]{16,}$/i;
+
+export type HttpLatencyEndpointStats = {
+  count: number;
+  p50_ms: number | null;
+  p95_ms: number | null;
+  p99_ms: number | null;
+};
+
+export type HttpLatencySnapshot = {
+  window_seconds: number;
+  enabled: boolean;
+  endpoints: Record<string, HttpLatencyEndpointStats>;
+};
+
+type LatencySample = {
+  timestampMs: number;
+  durationMs: number;
+};
+
+type RouteBucket = {
+  samples: LatencySample[];
+  lastUsedMs: number;
+};
+
+export type HttpLatencyTrackerOptions = {
+  windowMs?: number;
+  maxRoutes?: number;
+  maxSamples?: number;
+  enabled?: boolean;
+};
+
+function normalizePathSegment(segment: string): string {
+  if (UUID_PATTERN.test(segment) || LONG_HEX_PATTERN.test(segment)) {
+    return ":id";
+  }
+  return segment;
+}
+
+function normalizePathFromUrl(url: string): string {
+  const pathOnly = url.split("?")[0].split("#")[0];
+  if (!pathOnly || pathOnly === "/") {
+    return "/";
+  }
+  const segments = pathOnly.split("/").filter(Boolean);
+  const normalized = segments.map(normalizePathSegment).join("/");
+  return `/${normalized}`;
+}
+
+export function normalizeHttpRouteKey(
+  method: string,
+  url: string,
+  routeTemplate?: string,
+): string {
+  const normalizedMethod = method.toUpperCase();
+  const path = routeTemplate
+    ? routeTemplate.split("?")[0]
+    : normalizePathFromUrl(url);
+  return `${normalizedMethod} ${path}`;
+}
+
+function nearestRankPercentile(sortedValues: number[], percentile: number): number | null {
+  if (sortedValues.length === 0) {
+    return null;
+  }
+  const rank = Math.ceil(percentile * sortedValues.length);
+  const index = Math.max(0, Math.min(sortedValues.length - 1, rank - 1));
+  return Math.round(sortedValues[index] * 10) / 10;
+}
+
+function buildEndpointStats(samples: LatencySample[]): HttpLatencyEndpointStats {
+  if (samples.length === 0) {
+    return {
+      count: 0,
+      p50_ms: null,
+      p95_ms: null,
+      p99_ms: null,
+    };
+  }
+
+  const sorted = samples.map((sample) => sample.durationMs).sort((a, b) => a - b);
+  return {
+    count: sorted.length,
+    p50_ms: nearestRankPercentile(sorted, 0.5),
+    p95_ms: nearestRankPercentile(sorted, 0.95),
+    p99_ms: nearestRankPercentile(sorted, 0.99),
+  };
+}
+
+export class HttpLatencyTracker {
+  private readonly windowMs: number;
+  private readonly maxRoutes: number;
+  private readonly maxSamples: number;
+  private readonly enabled: boolean;
+  private readonly routes = new Map<string, RouteBucket>();
+
+  constructor(options?: HttpLatencyTrackerOptions) {
+    this.windowMs = options?.windowMs ?? DEFAULT_WINDOW_MS;
+    this.maxRoutes = options?.maxRoutes ?? DEFAULT_MAX_ROUTES;
+    this.maxSamples = options?.maxSamples ?? DEFAULT_MAX_SAMPLES_PER_ROUTE;
+    this.enabled = options?.enabled ?? true;
+  }
+
+  record(method: string, url: string, durationMs: number, routeTemplate?: string): void {
+    if (!this.enabled) {
+      return;
+    }
+
+    const pathOnly = url.split("?")[0].split("#")[0];
+    if (EXCLUDED_PREFIXES.some((prefix) => pathOnly === prefix || pathOnly.startsWith(prefix))) {
+      return;
+    }
+
+    const routeKey = normalizeHttpRouteKey(method, url, routeTemplate);
+    const now = Date.now();
+    let bucket = this.routes.get(routeKey);
+    if (!bucket) {
+      this.evictIfNeeded(routeKey, now);
+      bucket = { samples: [], lastUsedMs: now };
+      this.routes.set(routeKey, bucket);
+    }
+
+    bucket.lastUsedMs = now;
+    bucket.samples.push({ timestampMs: now, durationMs });
+    this.pruneBucket(bucket, now);
+    while (bucket.samples.length > this.maxSamples) {
+      bucket.samples.shift();
+    }
+  }
+
+  snapshot(): HttpLatencySnapshot {
+    const now = Date.now();
+    const endpoints: Record<string, HttpLatencyEndpointStats> = {};
+
+    for (const [routeKey, bucket] of this.routes.entries()) {
+      this.pruneBucket(bucket, now);
+      if (bucket.samples.length === 0) {
+        continue;
+      }
+      endpoints[routeKey] = buildEndpointStats(bucket.samples);
+    }
+
+    return {
+      window_seconds: Math.round(this.windowMs / 1000),
+      enabled: this.enabled,
+      endpoints,
+    };
+  }
+
+  reset(): void {
+    this.routes.clear();
+  }
+
+  private pruneBucket(bucket: RouteBucket, now: number): void {
+    const cutoff = now - this.windowMs;
+    bucket.samples = bucket.samples.filter((sample) => sample.timestampMs >= cutoff);
+  }
+
+  private evictIfNeeded(routeKey: string, now: number): void {
+    if (this.routes.has(routeKey) || this.routes.size < this.maxRoutes) {
+      return;
+    }
+
+    let oldestKey: string | null = null;
+    let oldestUsedMs = Number.POSITIVE_INFINITY;
+    for (const [key, bucket] of this.routes.entries()) {
+      if (bucket.lastUsedMs < oldestUsedMs) {
+        oldestUsedMs = bucket.lastUsedMs;
+        oldestKey = key;
+      }
+    }
+
+    if (oldestKey) {
+      this.routes.delete(oldestKey);
+    }
+  }
+}

--- a/agentchatbus-ts/src/transports/http/server.ts
+++ b/agentchatbus-ts/src/transports/http/server.ts
@@ -44,6 +44,7 @@ import {
 } from "../mcp/streamableHttp.js";
 import { resolveDefaultWorkspacePath } from "../../core/services/adapters/utils.js";
 import { WINDOWS_POWERSHELL } from "../../core/services/adapters/constants.js";
+import { HttpLatencyTracker } from "./httpLatencyTracker.js";
 
 // Allow tests to override the global memoryStore instance
 export let memoryStoreInstance: MemoryStore | null = null;
@@ -729,6 +730,7 @@ export function createHttpServer() {
   const cliMeetingOrchestrator = new CliMeetingOrchestrator(store, cliSessionManager);
   const loopbackHost = cfg.host === "0.0.0.0" ? "127.0.0.1" : cfg.host;
   const serverUrl = `http://${loopbackHost}:${cfg.port}`;
+  const httpLatencyTracker = new HttpLatencyTracker();
 
   function buildCliMcpLaunchEnv(input: {
     threadId: string;
@@ -822,6 +824,12 @@ export function createHttpServer() {
     });
   }
 
+  type TimingRequest = FastifyRequest & { acbRequestStartMs?: number };
+
+  fastify.addHook("onRequest", async (request) => {
+    (request as TimingRequest).acbRequestStartMs = Date.now();
+  });
+
   // ── SEC-05: Security middleware ──────────────────────────────────────────────
   // Config is read per-request (not captured at server creation time) to avoid
   // test isolation issues and support dynamic reconfiguration.
@@ -878,6 +886,17 @@ export function createHttpServer() {
         await reply.send({ detail: "Unauthorized: X-Admin-Token required in SHOW_AD mode" });
       }
     }
+  });
+
+  fastify.addHook("onResponse", async (request) => {
+    const timingRequest = request as TimingRequest;
+    const startMs = timingRequest.acbRequestStartMs;
+    if (startMs === undefined) {
+      return;
+    }
+    const durationMs = Date.now() - startMs;
+    const routeTemplate = request.routeOptions?.url;
+    httpLatencyTracker.record(request.method, request.url, durationMs, routeTemplate);
   });
 
   // ── End SEC-05 ───────────────────────────────────────────────────────────────
@@ -2951,7 +2970,10 @@ export function createHttpServer() {
     return { results, total: results.length, query: q };
   });
 
-  fastify.get("/api/metrics", async () => store.getMetrics());
+  fastify.get("/api/metrics", async () => ({
+    ...store.getMetrics(),
+    http: httpLatencyTracker.snapshot(),
+  }));
 
   fastify.get("/api/debug/sse-status", async () => ({
     subscribers: eventBus.listenerCount()

--- a/agentchatbus-ts/tests/integration/httpServer.test.ts
+++ b/agentchatbus-ts/tests/integration/httpServer.test.ts
@@ -1002,3 +1002,69 @@ describe("HTTP compatibility shell", () => {
     await server.close();
   });
 });
+
+describe("HTTP latency metrics", () => {
+  beforeAll(() => {
+    process.env.AGENTCHATBUS_TEST_DB = ":memory:";
+  });
+
+  beforeEach(() => {
+    if (memoryStoreInstance) {
+      memoryStoreInstance.reset();
+    }
+  });
+
+  it("records per-route latency on GET /api/metrics", async () => {
+    const server = createHttpServer();
+
+    for (let index = 0; index < 3; index += 1) {
+      const healthResponse = await server.inject({
+        method: "GET",
+        url: "/health",
+      });
+      expect(healthResponse.statusCode).toBe(200);
+    }
+
+    const metricsResponse = await server.inject({
+      method: "GET",
+      url: "/api/metrics",
+    });
+    expect(metricsResponse.statusCode).toBe(200);
+
+    const metrics = metricsResponse.json();
+    expect(metrics.http.enabled).toBe(true);
+    expect(metrics.http.endpoints["GET /health"].count).toBeGreaterThanOrEqual(3);
+    expect(metrics.messages.avg_latency_ms).toBeDefined();
+
+    await server.close();
+  });
+
+  it("normalizes dynamic thread routes in http.endpoints keys", async () => {
+    const server = createHttpServer();
+    const auth = (await server.inject({
+      method: "POST",
+      url: "/api/agents/register",
+      payload: { ide: "VSCode", model: "latency-normalize" },
+    })).json();
+
+    const threadResponse = await server.inject({
+      method: "POST",
+      url: "/api/threads",
+      headers: { "x-agent-token": auth.token },
+      payload: { topic: "latency-thread", creator_agent_id: auth.agent_id },
+    });
+    expect(threadResponse.statusCode).toBe(201);
+
+    const metricsResponse = await server.inject({
+      method: "GET",
+      url: "/api/metrics",
+    });
+    expect(metricsResponse.statusCode).toBe(200);
+
+    const endpoints = metricsResponse.json().http.endpoints as Record<string, unknown>;
+    expect(endpoints["POST /api/threads"]).toBeDefined();
+    expect(Object.keys(endpoints).some((key) => /\/api\/threads\/[0-9a-f-]{36}/i.test(key))).toBe(false);
+
+    await server.close();
+  });
+});

--- a/agentchatbus-ts/tests/unit/test_http_latency_tracker.test.ts
+++ b/agentchatbus-ts/tests/unit/test_http_latency_tracker.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  HttpLatencyTracker,
+  normalizeHttpRouteKey,
+} from "../../src/transports/http/httpLatencyTracker.js";
+
+describe("HttpLatencyTracker", () => {
+  it("normalizeHttpRouteKey collapses UUID thread ids to :id", () => {
+    const uuid = "550e8400-e29b-41d4-a716-446655440000";
+    expect(
+      normalizeHttpRouteKey("GET", `/api/threads/${uuid}/messages`),
+    ).toBe("GET /api/threads/:id/messages");
+    expect(
+      normalizeHttpRouteKey("POST", `/api/threads/${uuid}/messages`),
+    ).toBe("POST /api/threads/:id/messages");
+  });
+
+  it("normalizeHttpRouteKey prefers route template when provided", () => {
+    expect(
+      normalizeHttpRouteKey(
+        "GET",
+        "/api/threads/550e8400-e29b-41d4-a716-446655440000",
+        "/api/threads/:threadId",
+      ),
+    ).toBe("GET /api/threads/:threadId");
+  });
+
+  it("percentiles on 1..10 yield p50=5 and p95=10", () => {
+    const tracker = new HttpLatencyTracker({ maxSamples: 20 });
+    for (let value = 1; value <= 10; value += 1) {
+      tracker.record("GET", "/health", value);
+    }
+
+    const snapshot = tracker.snapshot();
+    const health = snapshot.endpoints["GET /health"];
+    expect(health.count).toBe(10);
+    expect(health.p50_ms).toBe(5);
+    expect(health.p95_ms).toBe(10);
+    expect(health.p99_ms).toBe(10);
+  });
+
+  it("window expiry drops old samples", () => {
+    const tracker = new HttpLatencyTracker({ windowMs: 1000, maxSamples: 10 });
+    const now = Date.now();
+    tracker.record("GET", "/health", 5);
+    (tracker as any).routes.get("GET /health").samples[0].timestampMs = now - 2000;
+
+    const snapshot = tracker.snapshot();
+    expect(snapshot.endpoints["GET /health"]).toBeUndefined();
+  });
+
+  it("excluded prefixes are skipped", () => {
+    const tracker = new HttpLatencyTracker();
+    tracker.record("GET", "/static/app.js", 12);
+    tracker.record("GET", "/favicon.ico", 8);
+
+    const snapshot = tracker.snapshot();
+    expect(snapshot.endpoints).toEqual({});
+  });
+
+  it("maxRoutes LRU eviction keeps newest routes", () => {
+    const tracker = new HttpLatencyTracker({ maxRoutes: 2, maxSamples: 4 });
+    tracker.record("GET", "/route-a", 1);
+    tracker.record("GET", "/route-b", 2);
+    tracker.record("GET", "/route-c", 3);
+
+    const snapshot = tracker.snapshot();
+    expect(snapshot.endpoints["GET /route-a"]).toBeUndefined();
+    expect(snapshot.endpoints["GET /route-b"]).toBeDefined();
+    expect(snapshot.endpoints["GET /route-c"]).toBeDefined();
+  });
+
+  it("reset clears tracked state", () => {
+    const tracker = new HttpLatencyTracker();
+    tracker.record("GET", "/health", 4);
+    expect(tracker.snapshot().endpoints["GET /health"]).toBeDefined();
+
+    tracker.reset();
+    expect(tracker.snapshot().endpoints).toEqual({});
+  });
+});

--- a/agentchatbus-ts/tests/unit/test_metrics.test.ts
+++ b/agentchatbus-ts/tests/unit/test_metrics.test.ts
@@ -274,6 +274,11 @@ describe('Metrics Unit Tests', () => {
     expect(m.agents.online).toBeDefined();
   });
 
+  it('metrics from MemoryStore does not include http transport section', () => {
+    const m = store.getMetrics() as Record<string, unknown>;
+    expect(m.http).toBeUndefined();
+  });
+
   // Ported from Python: test_api_metrics_uptime_positive
   it('metrics uptime is positive after start', () => {
     const m = store.getMetrics();

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -42,7 +42,24 @@ The server exposes a plain REST API used by the web console and integration scri
 | Method | Path | Description |
 |---|---|---|
 | `GET` | `/api/search` | Full-text search across messages. Required: `?q=...`. Optional: `?thread_id=...&limit=50` (max 200). Uses SQLite FTS5. |
-| `GET` | `/api/metrics` | Bus-level observability metrics: thread counts, message rates, inter-message latency, stop_reasons, agents. Unlike `/health`, this queries the DB. |
+| `GET` | `/api/metrics` | Bus-level observability metrics: thread counts, message rates, inter-message latency (`messages.avg_latency_ms`), stop_reasons, agents, plus in-process HTTP latency (`http`). Unlike `/health`, this queries the DB for bus metrics; `http` is collected by Fastify hooks. |
+
+Example `http` section (abbreviated):
+
+```json
+{
+  "http": {
+    "window_seconds": 900,
+    "enabled": true,
+    "endpoints": {
+      "GET /health": { "count": 12, "p50_ms": 1.2, "p95_ms": 3.4, "p99_ms": 5.1 },
+      "GET /api/metrics": { "count": 2, "p50_ms": 4.0, "p95_ms": 6.0, "p99_ms": 6.0 }
+    }
+  }
+}
+```
+
+`http.endpoints` keys are `METHOD` + normalized route (dynamic ids collapsed to `:id` or route template). Self-sampling is expected: `GET /api/metrics` appears in its own `endpoints` map because the metrics request is tracked like any other GET.
 
 ---
 

--- a/vscode-agentchatbus/package-lock.json
+++ b/vscode-agentchatbus/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentchatbus",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentchatbus",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "dependencies": {
         "eventsource": "^2.0.2"
       },

--- a/vscode-agentchatbus/package.json
+++ b/vscode-agentchatbus/package.json
@@ -7,7 +7,7 @@
   "name": "agentchatbus",
   "displayName": "AgentChatBus",
   "description": "AgentChatBus client for VS Code",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "icon": "resources/bus_128.png",
   "engines": {
     "vscode": "^1.105.0"


### PR DESCRIPTION
## Summary

- Add in-process HTTP latency tracking via Fastify hooks (onRequest before SEC-05, onResponse after handlers).
- Expose rolling-window p50/p95/p99 per normalized route on existing GET /api/metrics under a new top-level `http` object.
- Complements UP-22 `messages.avg_latency_ms` (inter-message SQLite gap) with handler wall-clock latency per route.

## REST surface

`GET /api/metrics` now includes an `http` section with `window_seconds`, `enabled`, and `endpoints` keyed by `METHOD path` with `count`, `p50_ms`, `p95_ms`, `p99_ms`.

Self-sampling: `GET /api/metrics` may appear in `http.endpoints` (expected).

## Tests

```bash
npx vitest run tests/unit/test_http_latency_tracker.test.ts
npx vitest run tests/unit/test_metrics.test.ts
npx vitest run tests/integration/httpServer.test.ts
```

All green locally.
