### PR TITLE
feat(web-ui): split-view thread compare (UI-04)

### DIFF
--- a/agentchatbus-ts/web-ui/css/main.css
+++ b/agentchatbus-ts/web-ui/css/main.css
@@ -799,6 +799,124 @@ body[data-theme="light"] .thread-item .ti-pin-btn {
   min-height: 0;
 }
 
+#main-panels {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+#main.compare-mode #main-panels {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 0;
+}
+
+#primary-panel {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+.compare-banner {
+  flex-shrink: 0;
+  padding: 8px 16px;
+  font-size: 13px;
+  text-align: center;
+  color: var(--text-2);
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border);
+}
+
+.compare-panel {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  border-left: 1px solid var(--border);
+  background: var(--surface-1);
+}
+
+.compare-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 16px;
+  height: 52px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.compare-panel-title {
+  flex: 1;
+  min-width: 0;
+  font-size: 14px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.compare-panel-close {
+  flex-shrink: 0;
+  padding: 6px 12px;
+  font-size: 12px;
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-1);
+  cursor: pointer;
+}
+
+.compare-panel-close:hover {
+  background: var(--surface-2);
+}
+
+.compare-messages-wrap {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+}
+
+#compare-sys-prompt-area {
+  flex-shrink: 0;
+}
+
+.compare-chat-body {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  display: flex;
+}
+
+.compare-messages-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 16px;
+}
+
+#compare-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+@media (max-width: 900px) {
+  #main.compare-mode #main-panels {
+    display: flex;
+    flex-direction: column;
+  }
+
+  #main.compare-mode .compare-panel {
+    display: none !important;
+  }
+}
+
 /* Thread header */
 #thread-header {
   padding: 0 20px;

--- a/agentchatbus-ts/web-ui/index.html
+++ b/agentchatbus-ts/web-ui/index.html
@@ -10,7 +10,7 @@
   <link
     href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
     rel="stylesheet" />
-  <link rel="stylesheet" href="/static/css/main.css?v=30" />
+  <link rel="stylesheet" href="/static/css/main.css?v=31" />
   <link rel="stylesheet" href="/static/vendor/xterm/css/xterm.css" />
 </head>
 
@@ -88,6 +88,10 @@
     <div id="main">
       <acb-thread-header></acb-thread-header>
 
+      <div id="compare-banner" class="compare-banner" hidden role="status" aria-live="polite"></div>
+
+      <div id="main-panels">
+        <div id="primary-panel">
       <!-- UI-02: Search bar -->
       <div id="search-bar" role="search" aria-label="Search messages">
         <div class="search-bar-row">
@@ -162,6 +166,23 @@
           <div id="agent-status-info">ℹ️</div>
         </div>
       </div>
+        </div>
+
+        <div id="compare-panel" class="compare-panel" hidden>
+          <div class="compare-panel-header">
+            <h3 id="compare-panel-title" class="compare-panel-title">Compare</h3>
+            <button id="compare-panel-close" type="button" class="compare-panel-close" aria-label="Close compare view">Close</button>
+          </div>
+          <div id="compare-messages-wrap" class="compare-messages-wrap">
+            <div id="compare-sys-prompt-area"></div>
+            <div id="compare-chat-body" class="compare-chat-body">
+              <div id="compare-messages-scroll" class="compare-messages-scroll">
+                <div id="compare-messages"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 
@@ -179,7 +200,7 @@
   <script src="/static/js/shared-theme.js?v=2"></script>
   <script src="/static/js/shared-utils.js?v=3"></script>
   <script src="/static/js/shared-message-renderer.js?v=5"></script>
-  <script src="/static/js/shared-sse.js?v=3"></script>
+  <script src="/static/js/shared-sse.js?v=4"></script>
   <script src="/static/vendor/xterm/lib/xterm.js"></script>
   <script src="/static/vendor/xterm-addon-fit/lib/addon-fit.js"></script>
   <script src="/static/js/shared-cli-sessions.js?v=18"></script>
@@ -190,18 +211,19 @@
   <script src="/static/js/components/acb-filter-actions.js?v=2"></script>
   <script src="/static/js/components/acb-filter-row.js?v=2"></script>
   <script src="/static/js/components/acb-thread-filter-shell.js?v=2"></script>
-  <script src="/static/js/components/acb-thread-context-menu.js?v=2"></script>
+  <script src="/static/js/components/acb-thread-context-menu.js?v=3"></script>
   <script src="/static/js/components/acb-thread-header.js?v=7"></script>
-  <script src="/static/js/components/acb-thread-item.js?v=3"></script>
+  <script src="/static/js/components/acb-thread-item.js?v=4"></script>
   <script src="/static/js/components/acb-message-tail-meta.js?v=1"></script>
   <script src="/static/js/components/acb-admin-switch-card.js?v=4"></script>
   <script src="/static/js/components/acb-compose-shell.js?v=3"></script>
   <script src="/static/js/components/acb-agent-status-shell.js?v=3"></script>
-  <script src="/static/js/shared-threads.js?v=8"></script>
+  <script src="/static/js/shared-split-view.js?v=1"></script>
+  <script src="/static/js/shared-threads.js?v=9"></script>
   <script src="/static/js/shared-agent-status.js?v=2"></script>
   <script src="/static/js/components/acb-agent-status-item.js?v=2"></script>
   <script src="/static/js/shared-agents.js?v=4"></script>
-  <script src="/static/js/shared-chat.js?v=7"></script>
+  <script src="/static/js/shared-chat.js?v=8"></script>
   <script src="/static/js/shared-nav-sidebar.js?v=1"></script>
   <script src="/static/js/shared-tooltip.js?v=2"></script>
   <script src="/static/js/components/acb-confirm-dialog.js?v=2"></script>
@@ -377,19 +399,7 @@
       if (window.AcbSearch) window.AcbSearch.init();
       await syncShowAdPolicy();
       await refreshThreadSidebarData();
-      const storedActiveThread = loadStoredActiveThread();
-      if (storedActiveThread?.id) {
-        try {
-          await selectThread(
-            storedActiveThread.id,
-            storedActiveThread.topic || storedActiveThread.id,
-            storedActiveThread.status || 'discuss',
-          );
-        } catch {
-          clearStoredActiveThread();
-          resetThreadSelection();
-        }
-      }
+      await restoreBootThreadSelection();
       updateOnlinePresence();
       startSSE();
       setInterval(refreshThreadSidebarData, 10000);
@@ -425,8 +435,29 @@
       hideAgentTooltip();
     });
     document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape') hideThreadContextMenu();
+      if (e.key !== 'Escape') {
+        return;
+      }
+      const menu = document.getElementById('thread-context-menu');
+      if (menu?.classList.contains('visible')) {
+        hideThreadContextMenu();
+        return;
+      }
+      if (window.AcbSplitView?.isCompareMode()) {
+        exitCompare();
+      }
     });
+    window.addEventListener('hashchange', () => {
+      void handleThreadHashChange();
+    });
+
+    const comparePanelCloseBtn = document.getElementById('compare-panel-close');
+    if (comparePanelCloseBtn) {
+      comparePanelCloseBtn.addEventListener('click', () => {
+        exitCompare();
+      });
+    }
+
     window.addEventListener('resize', () => {
       hideThreadContextMenu();
       hideAgentTooltip();
@@ -1035,9 +1066,13 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
     function startSSE() {
       return window.AcbSSE.startSSE({
         getActiveThreadId: () => activeThreadId,
+        getCompareThreadId: () => window.AcbSplitView?.getCompareThreadId() || null,
         onMsgNew: async () => loadNewMessages(),
         onTranscriptUpdate: async () => reloadTranscript(),
         onMsgEdit: async (message) => applyEditedMessage(message),
+        onCompareMsgNew: async () => loadCompareNewMessages(),
+        onCompareTranscriptUpdate: async () => reloadCompareTranscript(),
+        onCompareMsgEdit: async (message) => applyCompareEditedMessage(message),
         onThreadEvent: async () => refreshThreads(),
         onAgentPresence: async () => refreshThreadSidebarData(),
         onCliSessionEvent: async (event) => {
@@ -1093,6 +1128,8 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
         },
         resetThreadSelection,
         onSelectThread: selectThread,
+        onCompareWithCurrent,
+        onThreadsRefreshed: (threads) => ensureCompareThreadStillExists(threads),
         onTogglePin: async (threadId, pinned) => {
           window.AcbThreads.setThreadPinned(threadId, pinned);
           await refreshThreads();
@@ -1188,7 +1225,16 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
     async function selectThread(id, topic, status, initialSyncContext = null) {
       // Close mobile sidebar when selecting thread
       closeMobileSidebar();
+      if (window.AcbSplitView?.getCompareThreadId() === id) {
+        await exitCompare();
+      }
       saveStoredActiveThread({ id, topic, status });
+      if (window.AcbSplitView) {
+        window.AcbSplitView.writeThreadHash({
+          threadId: id,
+          compareId: window.AcbSplitView.getCompareThreadId() || null,
+        });
+      }
       if (window.AcbCliSessions) {
         window.AcbCliSessions.restoreThreadFromCache?.(id);
       }
@@ -1224,6 +1270,230 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
     }
     // Expose globally for AcbSearch navigation
     window.selectThread = selectThread;
+
+    function compareScrollBottom(smooth = false) {
+      const box = document.getElementById('compare-messages-scroll');
+      if (!box) return;
+      setTimeout(() => {
+        void box.offsetHeight;
+        if (smooth) {
+          box.scrollTo({ top: box.scrollHeight, behavior: 'smooth' });
+        } else {
+          box.scrollTop = box.scrollHeight;
+        }
+      }, 50);
+    }
+
+    async function loadCompareTranscript(compareId) {
+      const targets = window.AcbSplitView.getMessageTargets(window.AcbSplitView.TARGET_COMPARE);
+      return window.AcbChat.loadTranscript({
+        id: compareId,
+        api,
+        clearThreadParticipants: () => {},
+        rebuildActiveThreadParticipants: () => {},
+        appendBubble: (m) => appendBubble(m, {
+          target: window.AcbSplitView.TARGET_COMPARE,
+          readOnly: true,
+        }),
+        updateOnlinePresence: () => {},
+        updateStatusBar: async () => {},
+        setLastSeq: (s) => window.AcbSplitView.setCompareLastSeq(s),
+        scrollBottom: compareScrollBottom,
+        refreshAdmin: false,
+        clearCliCache: false,
+        messagesEl: targets.messagesEl,
+        sysPromptEl: targets.sysPromptEl,
+        skipCliActivity: true,
+      });
+    }
+
+    async function loadCompareNewMessages() {
+      const compareId = window.AcbSplitView.getCompareThreadId();
+      if (!compareId) return;
+      const targets = window.AcbSplitView.getMessageTargets(window.AcbSplitView.TARGET_COMPARE);
+      return window.AcbChat.loadNewMessagesForThread({
+        threadId: compareId,
+        getLastSeq: () => window.AcbSplitView.getCompareLastSeq(),
+        api,
+        appendBubble: (m) => appendBubble(m, {
+          target: window.AcbSplitView.TARGET_COMPARE,
+          readOnly: true,
+        }),
+        setLastSeq: (fn) => window.AcbSplitView.setCompareLastSeq(fn),
+        scrollBottom: compareScrollBottom,
+        messagesEl: targets.messagesEl,
+        skipPresence: true,
+      });
+    }
+
+    async function reloadCompareTranscript() {
+      const compareId = window.AcbSplitView.getCompareThreadId();
+      if (!compareId) return;
+      const targets = window.AcbSplitView.getMessageTargets(window.AcbSplitView.TARGET_COMPARE);
+      return window.AcbChat.reloadTranscriptForThread({
+        threadId: compareId,
+        api,
+        clearThreadParticipants: () => {},
+        rebuildActiveThreadParticipants: () => {},
+        appendBubble: (m) => appendBubble(m, {
+          target: window.AcbSplitView.TARGET_COMPARE,
+          readOnly: true,
+        }),
+        updateOnlinePresence: () => {},
+        updateStatusBar: async () => {},
+        setLastSeq: (s) => window.AcbSplitView.setCompareLastSeq(s),
+        scrollBottom: compareScrollBottom,
+        messagesEl: targets.messagesEl,
+        sysPromptEl: targets.sysPromptEl,
+        skipCliActivity: true,
+      });
+    }
+
+    async function enterCompare(compareId, topic = '') {
+      if (!window.AcbSplitView || !activeThreadId) {
+        return false;
+      }
+      return window.AcbSplitView.enterCompare(compareId, {
+        activeThreadId,
+        topic,
+        onLoadTranscript: loadCompareTranscript,
+      });
+    }
+
+    async function exitCompare() {
+      if (!window.AcbSplitView) {
+        return false;
+      }
+      return window.AcbSplitView.exitCompare({ activeThreadId });
+    }
+
+    async function onCompareWithCurrent(compareId, topic, status) {
+      void status;
+      if (!window.AcbSplitView?.isCompareViewportOk()) {
+        window.AcbSplitView.showCompareBlockedBanner();
+        return;
+      }
+      await enterCompare(compareId, topic);
+    }
+
+    async function compareThreadFromMenu() {
+      if (!contextMenuThread?.id) return;
+      hideThreadContextMenu();
+      await onCompareWithCurrent(contextMenuThread.id, contextMenuThread.topic, contextMenuThread.status);
+    }
+    window.compareThreadFromMenu = compareThreadFromMenu;
+
+    async function resolveThreadFromList(threadId) {
+      const normalizedId = String(threadId || '').trim();
+      if (!normalizedId) return null;
+      const cached = window.AcbThreads.getCachedAllThreads().find((thread) => thread.id === normalizedId);
+      if (cached) return cached;
+      try {
+        const response = await api('/api/threads?include_archived=1&limit=500');
+        return (response?.threads || []).find((thread) => thread.id === normalizedId) || null;
+      } catch {
+        return null;
+      }
+    }
+
+    async function restoreBootThreadSelection() {
+      if (!window.AcbSplitView) return;
+      const { threadId, compareId } = window.AcbSplitView.parseThreadHash();
+      let bootedPrimary = false;
+
+      if (threadId) {
+        const thread = await resolveThreadFromList(threadId);
+        if (thread) {
+          try {
+            await selectThread(thread.id, thread.topic, thread.status);
+            bootedPrimary = true;
+          } catch {
+            window.AcbSplitView.writeThreadHash({ threadId: null, compareId: null });
+          }
+        } else {
+          window.AcbSplitView.writeThreadHash({ threadId: null, compareId: compareId || null });
+        }
+      }
+
+      if (!bootedPrimary) {
+        const storedActiveThread = loadStoredActiveThread();
+        if (storedActiveThread?.id) {
+          try {
+            await selectThread(
+              storedActiveThread.id,
+              storedActiveThread.topic || storedActiveThread.id,
+              storedActiveThread.status || 'discuss',
+            );
+            bootedPrimary = true;
+          } catch {
+            clearStoredActiveThread();
+            resetThreadSelection();
+          }
+        }
+      }
+
+      if (!bootedPrimary) {
+        return;
+      }
+
+      const hashCompareId = String(compareId || '').trim();
+      if (hashCompareId && hashCompareId !== activeThreadId && window.AcbSplitView.isCompareViewportOk()) {
+        const compareThread = await resolveThreadFromList(hashCompareId);
+        if (compareThread) {
+          await enterCompare(compareThread.id, compareThread.topic);
+          return;
+        }
+      }
+
+      if (!hashCompareId) {
+        const storedCompare = window.AcbSplitView.loadCompareThread();
+        if (storedCompare?.id && storedCompare.id !== activeThreadId && window.AcbSplitView.isCompareViewportOk()) {
+          const compareThread = await resolveThreadFromList(storedCompare.id);
+          if (compareThread) {
+            await enterCompare(compareThread.id, compareThread.topic || storedCompare.topic);
+          }
+        }
+      }
+    }
+
+    async function handleThreadHashChange() {
+      if (!window.AcbSplitView) return;
+      const { threadId, compareId } = window.AcbSplitView.parseThreadHash();
+
+      if (threadId && threadId !== activeThreadId) {
+        const thread = await resolveThreadFromList(threadId);
+        if (thread) {
+          await selectThread(thread.id, thread.topic, thread.status);
+        }
+      }
+
+      const normalizedCompareId = String(compareId || '').trim();
+      if (!normalizedCompareId) {
+        if (window.AcbSplitView.isCompareMode()) {
+          await exitCompare();
+        }
+        return;
+      }
+
+      if (
+        normalizedCompareId !== window.AcbSplitView.getCompareThreadId() &&
+        normalizedCompareId !== activeThreadId
+      ) {
+        const compareThread = await resolveThreadFromList(normalizedCompareId);
+        if (compareThread) {
+          await enterCompare(compareThread.id, compareThread.topic);
+        }
+      }
+    }
+
+    function ensureCompareThreadStillExists(threads) {
+      const compareId = window.AcbSplitView?.getCompareThreadId();
+      if (!compareId) return;
+      const list = Array.isArray(threads) ? threads : [];
+      if (!list.some((thread) => thread.id === compareId)) {
+        void exitCompare();
+      }
+    }
 
     function getThreadSyncContext(threadId = activeThreadId) {
       if (!threadId) return null;
@@ -1290,7 +1560,10 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
     }
 
     function openThreadContextMenu(event, thread) {
-      contextMenuThread = window.AcbThreads.openThreadContextMenu(event, thread, { showAd });
+      contextMenuThread = window.AcbThreads.openThreadContextMenu(event, thread, {
+        showAd,
+        activeThreadId,
+      });
       // 保存右键点击的位置，用于确认对话框定位
       contextMenuThread._clickX = event.clientX;
       contextMenuThread._clickY = event.clientY;
@@ -1418,6 +1691,9 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
     }
 
     function resetThreadSelection() {
+      if (window.AcbSplitView?.isCompareMode()) {
+        void exitCompare();
+      }
       if (activeThreadId) {
         threadSyncContexts.delete(activeThreadId);
       }
@@ -1432,9 +1708,16 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
       document.querySelectorAll('.thread-item').forEach(el => el.classList.remove('active'));
       document.getElementById('thread-header').style.display = 'none';
       document.getElementById('compose').classList.remove('visible');
-      document.getElementById('messages').innerHTML = EMPTY_STATE_TEMPLATE;
-      const sysArea = document.getElementById('sys-prompt-area');
+      const primaryTargets = window.AcbSplitView?.getMessageTargets(window.AcbSplitView?.TARGET_PRIMARY);
+      const messagesEl = primaryTargets?.messagesEl || document.getElementById('messages');
+      if (messagesEl) {
+        messagesEl.innerHTML = EMPTY_STATE_TEMPLATE;
+      }
+      const sysArea = primaryTargets?.sysPromptEl || document.getElementById('sys-prompt-area');
       if (sysArea) sysArea.innerHTML = '';
+      if (window.AcbSplitView) {
+        window.AcbSplitView.writeThreadHash({ threadId: null, compareId: null });
+      }
       if (window.AcbCliSessions) window.AcbCliSessions.renderThread(null);
       updateOnlinePresence();
       updateCloseThreadButton();
@@ -1617,6 +1900,24 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
       setTimeout(() => target.classList.remove('msg-jump-highlight'), 1500);
     };
 
+    function applyCompareEditedMessage(message) {
+      const compareId = window.AcbSplitView?.getCompareThreadId();
+      if (!message?.id || !compareId || message.thread_id !== compareId) {
+        return;
+      }
+      const targets = window.AcbSplitView.getMessageTargets(window.AcbSplitView.TARGET_COMPARE);
+      const root = targets.messagesEl;
+      if (!root) return;
+      const row = root.querySelector(`[data-msg-id="${CSS.escape(String(message.id))}"]`);
+      if (!row || row.classList.contains('msg-editing')) {
+        return;
+      }
+      const bubbleEl = row.querySelector('.bubble-v2');
+      if (!bubbleEl) return;
+      renderMessageBubble(row, bubbleEl, message.content, message.metadata);
+      syncEditedIndicator(row, message);
+    }
+
     // UI-13: event delegation -- intercepts clicks on any .msg-reply-quote in #messages
     document.getElementById('messages')?.addEventListener('click', (e) => {
       const btn = e.target.closest('button.msg-reply-quote');
@@ -1625,14 +1926,21 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
       if (targetId) window.AcbScrollToMsg(targetId);
     });
 
-    function appendBubble(m) {
-      const box = document.getElementById('messages');
+    function appendBubble(m, options = {}) {
+      const targetKey = options.target || window.AcbSplitView?.TARGET_PRIMARY || 'primary';
+      const readOnly = Boolean(options.readOnly);
+      const targets = window.AcbSplitView?.getMessageTargets(targetKey) || {
+        messagesEl: document.getElementById('messages'),
+        sysPromptEl: document.getElementById('sys-prompt-area'),
+      };
+      const box = targets.messagesEl;
+      if (!box) return;
 
       // ---- Deduplication check (also check sys-prompt-area for seq=0) --------
       const messageId = String(m.id ?? '').trim();
       const hasSeq = typeof m.seq === 'number' && Number.isFinite(m.seq);
       const seq = hasSeq ? String(m.seq) : '';
-      const sysPromptArea = document.getElementById('sys-prompt-area');
+      const sysPromptArea = targets.sysPromptEl;
       const escapedMessageId = messageId && window.CSS && typeof window.CSS.escape === 'function'
         ? window.CSS.escape(messageId)
         : messageId;
@@ -1655,7 +1963,7 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
 
         // Frontend fallback: still render legacy human-decision admin switch cards
         // if old messages exist in history.
-        if (metaObj && (
+        if (!readOnly && metaObj && (
           metaObj.ui_type === 'admin_switch_confirmation_required'
           || metaObj.ui_type === 'admin_takeover_confirmation_required'
         )) {
@@ -1772,7 +2080,7 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
           promptBody.appendChild(promptCopyBtn);
 
           // UI-07: system prompt goes into its own full-width area (above chat-body)
-          const sysArea = document.getElementById('sys-prompt-area') || box;
+          const sysArea = targets.sysPromptEl || box;
           sysArea.innerHTML = '';
           sysArea.appendChild(wrapper);
           return;
@@ -1892,7 +2200,7 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
           <button class="msg-copy-btn" title="Copy message" aria-label="Copy message content" onclick="window.AcbCopyMsg(this)">
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
           </button>
-          ${!isSystem ? `<button class="msg-edit-btn toolbar-btn" aria-label="Edit message" onclick="window.AcbMsgEditStart(this)" data-msg-id="${esc(m.id)}" data-author="${esc(m.author)}">
+          ${!isSystem && !readOnly ? `<button class="msg-edit-btn toolbar-btn" aria-label="Edit message" onclick="window.AcbMsgEditStart(this)" data-msg-id="${esc(m.id)}" data-author="${esc(m.author)}">
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
           </button>` : ''}
         </div>
@@ -1941,7 +2249,7 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
 
       // Set rich tooltip for edit button
       const editBtn = row.querySelector('.msg-edit-btn');
-      if (editBtn && window.AcbTooltip) {
+      if (!readOnly && editBtn && window.AcbTooltip) {
         const helpText = `
           <div style="padding: 10px; max-width: 280px; font-size: 13px; line-height: 1.5; color: var(--text-1);">
             <div style="font-weight: 600; margin-bottom: 4px;">Edit message</div>
@@ -1983,30 +2291,33 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
       }
 
       box.appendChild(row);
-      if (isAgentMessage && window.AcbChat?.refreshCliCardsForAuthor) {
+      if (!readOnly && isAgentMessage && window.AcbChat?.refreshCliCardsForAuthor) {
         window.AcbChat.refreshCliCardsForAuthor(String(m.author_id ?? m.author ?? ''));
       }
-      if (isHuman && window.AcbChat?.refreshHumanDeliveryIndicators) {
+      if (!readOnly && isHuman && window.AcbChat?.refreshHumanDeliveryIndicators) {
         window.AcbChat.refreshHumanDeliveryIndicators(window.currentThreadId || null);
       }
-      if (window.AcbNavSidebar) window.AcbNavSidebar.onNewMessage();
+      if (!readOnly && window.AcbNavSidebar) window.AcbNavSidebar.onNewMessage();
 
-      // UI-07: collapse system prompt on first real message
-      const sysArea = document.getElementById('sys-prompt-area');
-      if (sysArea) {
-        const header = sysArea.querySelector('.msg-sys-prompt-header');
-        const body = sysArea.querySelector('.msg-sys-prompt-body');
-        if (header && body && header.getAttribute('aria-expanded') === 'true') {
-          header.setAttribute('aria-expanded', 'false');
-          header.classList.remove('is-expanded');
-          body.classList.add('collapsed');
-          const chevron = header.querySelector('.msg-sys-prompt-chevron');
-          const label = header.querySelector('.msg-sys-prompt-label');
-          if (chevron) chevron.innerHTML = '&#9660;';
-          if (label) label.textContent = 'Thread Instructions (system) — click to expand';
+      // UI-07: collapse system prompt on first real message (primary only)
+      if (!readOnly && targetKey === (window.AcbSplitView?.TARGET_PRIMARY || 'primary')) {
+        const sysArea = targets.sysPromptEl;
+        if (sysArea) {
+          const header = sysArea.querySelector('.msg-sys-prompt-header');
+          const body = sysArea.querySelector('.msg-sys-prompt-body');
+          if (header && body && header.getAttribute('aria-expanded') === 'true') {
+            header.setAttribute('aria-expanded', 'false');
+            header.classList.remove('is-expanded');
+            body.classList.add('collapsed');
+            const chevron = header.querySelector('.msg-sys-prompt-chevron');
+            const label = header.querySelector('.msg-sys-prompt-label');
+            if (chevron) chevron.innerHTML = '&#9660;';
+            if (label) label.textContent = 'Thread Instructions (system) — click to expand';
+          }
         }
       }
     }
+
     // ---- Typing indicator ----------------------------------------------------------------------------------------------------------
     function showTyping(agentId) {
       const box = document.getElementById('messages');

--- a/agentchatbus-ts/web-ui/js/components/acb-thread-context-menu.js
+++ b/agentchatbus-ts/web-ui/js/components/acb-thread-context-menu.js
@@ -6,6 +6,7 @@
       this.innerHTML = `
         <div id="thread-context-menu" role="menu">
           <button id="ctx-copy-name" class="ctx-item" type="button" role="menuitem" onclick="copyThreadNameFromMenu()">🧵 Copy Thread Name</button>
+          <button id="ctx-compare" class="ctx-item" type="button" role="menuitem" onclick="compareThreadFromMenu()" style="display: none;">🔀 Compare with current</button>
           <hr class="ctx-divider" aria-hidden="true">
           <button id="ctx-rename" class="ctx-item" type="button" role="menuitem" onclick="renameThreadFromMenu()">✏️ Rename</button>
           <button id="ctx-add-tag" class="ctx-item" type="button" role="menuitem" onclick="addTagFromMenu()">🏷️ Add tag…</button>

--- a/agentchatbus-ts/web-ui/js/components/acb-thread-item.js
+++ b/agentchatbus-ts/web-ui/js/components/acb-thread-item.js
@@ -15,7 +15,7 @@
     connectedCallback() {
       this.style.display = "block";
       if (!this._boundClick) {
-        this._boundClick = () => {
+        this._boundClick = (e) => {
           if (!this._thread) return;
           this.dispatchEvent(
             new CustomEvent("thread-select", {
@@ -24,6 +24,7 @@
                 id: this._thread.id,
                 topic: this._thread.topic,
                 status: this._thread.status,
+                shiftKey: Boolean(e.shiftKey),
               },
             })
           );
@@ -157,6 +158,7 @@
       this.setAttribute('data-thread-id', String(this._thread.id));
       this.setAttribute('role', 'listitem');
       this.setAttribute('aria-current', this._active ? 'true' : 'false');
+      this.title = 'Shift+click to compare with current thread';
       this.innerHTML = `
         <button class="ti-pin-btn${pinned ? " is-pinned" : ""}" type="button" aria-label="${pinned ? "Unpin thread" : "Pin thread"}" title="${pinned ? "Unpin thread" : "Pin thread"}">📌</button>
         ${waitingBadgeHtml}

--- a/agentchatbus-ts/web-ui/js/shared-chat.js
+++ b/agentchatbus-ts/web-ui/js/shared-chat.js
@@ -787,8 +787,11 @@
     scrollBottom,
     refreshAdmin = true,
     clearCliCache = true,
+    messagesEl = null,
+    sysPromptEl = null,
+    skipCliActivity = false,
   }) {
-    const box = document.getElementById("messages");
+    const box = messagesEl || document.getElementById("messages");
     if (!box) {
       return;
     }
@@ -797,24 +800,36 @@
       clearThreadParticipants();
     }
     box.innerHTML = "";
-    clearCliActivityRows(id, clearCliCache);
-    const sysPromptAreaEl = document.getElementById("sys-prompt-area");
-    if (sysPromptAreaEl) sysPromptAreaEl.innerHTML = "";
+    if (!skipCliActivity) {
+      clearCliActivityRows(id, clearCliCache);
+    }
+    const sysPromptAreaEl = sysPromptEl || document.getElementById("sys-prompt-area");
+    if (sysPromptAreaEl) {
+      sysPromptAreaEl.innerHTML = "";
+    }
     box.classList.add("loading-history");
 
     const msgs =
       (await api(`/api/threads/${id}/transcript?after_seq=0&limit=400&include_system_prompt=1`)) ||
       [];
-    rebuildActiveThreadParticipants(msgs);
+    if (typeof rebuildActiveThreadParticipants === "function") {
+      rebuildActiveThreadParticipants(msgs);
+    }
     msgs.forEach(appendBubble);
-    const cachedSessions = getThreadActivityCache(id);
-    if (cachedSessions && !clearCliCache) {
-      for (const session of cachedSessions.values()) {
-        renderCliActivitySession(session, false);
+    if (!skipCliActivity) {
+      const cachedSessions = getThreadActivityCache(id);
+      if (cachedSessions && !clearCliCache) {
+        for (const session of cachedSessions.values()) {
+          renderCliActivitySession(session, false);
+        }
       }
     }
-    updateOnlinePresence();
-    await updateStatusBar();
+    if (typeof updateOnlinePresence === "function") {
+      updateOnlinePresence();
+    }
+    if (typeof updateStatusBar === "function") {
+      await updateStatusBar();
+    }
     if (refreshAdmin) {
       await refreshThreadAdmin(id, api);
     }
@@ -822,7 +837,9 @@
     if (window.AcbMessageRenderer?.renderMermaidBlocks) {
       await window.AcbMessageRenderer.renderMermaidBlocks(box);
     }
-    scrollBottom(false);
+    if (typeof scrollBottom === "function") {
+      scrollBottom(false);
+    }
     box.classList.remove("loading-history");
   }
 
@@ -870,6 +887,63 @@
     });
   }
 
+  async function loadNewMessagesForThread({
+    threadId,
+    getLastSeq,
+    api,
+    getAgentPresenceKey,
+    getAgentDisplayName,
+    recordThreadAgentActivity,
+    appendBubble,
+    updateOnlinePresence,
+    updateStatusBar,
+    setLastSeq,
+    scrollBottom,
+    messagesEl = null,
+    skipPresence = false,
+  }) {
+    const normalizedThreadId = String(threadId || "").trim();
+    if (!normalizedThreadId) {
+      return [];
+    }
+
+    const cursor = getLastSeq();
+    const msgs =
+      (await api(`/api/threads/${normalizedThreadId}/messages?after_seq=${cursor}&limit=100`)) || [];
+
+    if (!skipPresence) {
+      msgs.forEach((m) => {
+        const key = getAgentPresenceKey(m);
+        const label = getAgentDisplayName(m);
+        if (key && typeof recordThreadAgentActivity === "function") {
+          recordThreadAgentActivity(key, label, m.created_at);
+        }
+      });
+    }
+
+    msgs.forEach(appendBubble);
+    if (typeof updateOnlinePresence === "function") {
+      updateOnlinePresence();
+    }
+    if (typeof updateStatusBar === "function") {
+      await updateStatusBar();
+    }
+
+    msgs.forEach((m) => {
+      setLastSeq((prev) => Math.max(prev, m.seq));
+    });
+
+    const box = messagesEl || document.getElementById("messages");
+    if (msgs.length && window.AcbMessageRenderer?.renderMermaidBlocks) {
+      await window.AcbMessageRenderer.renderMermaidBlocks(box);
+    }
+
+    if (msgs.length && typeof scrollBottom === "function") {
+      scrollBottom(true);
+    }
+    return msgs;
+  }
+
   async function loadNewMessages({
     getActiveThreadId,
     getLastSeq,
@@ -910,6 +984,42 @@
     }
 
     if (msgs.length) scrollBottom(true);
+  }
+
+  async function reloadTranscriptForThread({
+    threadId,
+    api,
+    clearThreadParticipants,
+    rebuildActiveThreadParticipants,
+    appendBubble,
+    updateOnlinePresence,
+    updateStatusBar,
+    setLastSeq,
+    scrollBottom,
+    messagesEl = null,
+    sysPromptEl = null,
+    skipCliActivity = false,
+  }) {
+    const normalizedThreadId = String(threadId || "").trim();
+    if (!normalizedThreadId) {
+      return;
+    }
+    await loadTranscript({
+      id: normalizedThreadId,
+      api,
+      clearThreadParticipants,
+      rebuildActiveThreadParticipants,
+      appendBubble,
+      updateOnlinePresence,
+      updateStatusBar,
+      setLastSeq,
+      scrollBottom,
+      refreshAdmin: false,
+      clearCliCache: false,
+      messagesEl,
+      sysPromptEl,
+      skipCliActivity,
+    });
   }
 
   async function reloadTranscript({
@@ -1103,6 +1213,9 @@
     refreshThreadAdmin,
     selectThread,
     reloadTranscript,
+    loadTranscript,
+    loadNewMessagesForThread,
+    reloadTranscriptForThread,
     loadNewMessages,
     sendMessage,
     handleKey,

--- a/agentchatbus-ts/web-ui/js/shared-split-view.js
+++ b/agentchatbus-ts/web-ui/js/shared-split-view.js
@@ -1,0 +1,251 @@
+(function () {
+  const COMPARE_THREAD_STORAGE_KEY = "acb-compare-thread";
+  const MIN_COMPARE_WIDTH_PX = 900;
+  const TARGET_PRIMARY = "primary";
+  const TARGET_COMPARE = "compare";
+
+  let compareThreadId = null;
+  let compareThreadTopic = "";
+  let compareLastSeq = 0;
+  let bannerTimer = null;
+
+  function parseThreadHash(hash = location.hash) {
+    const body = String(hash || "").replace(/^#/, "");
+    if (!body) {
+      return { threadId: "", compareId: "" };
+    }
+    const params = new URLSearchParams(body.includes("=") ? body : `thread=${body}`);
+    return {
+      threadId: String(params.get("thread") || "").trim(),
+      compareId: String(params.get("compare") || "").trim(),
+    };
+  }
+
+  function writeThreadHash({ threadId, compareId }) {
+    const params = new URLSearchParams();
+    if (threadId) {
+      params.set("thread", threadId);
+    }
+    if (compareId) {
+      params.set("compare", compareId);
+    }
+    const next = params.toString();
+    history.replaceState(null, "", next ? `#${next}` : location.pathname);
+  }
+
+  function isCompareViewportOk() {
+    return window.innerWidth >= MIN_COMPARE_WIDTH_PX;
+  }
+
+  function showCompareBlockedBanner(message = "Compare view needs a wider window") {
+    const banner = document.getElementById("compare-banner");
+    if (!banner) {
+      return;
+    }
+    banner.textContent = message;
+    banner.hidden = false;
+    if (bannerTimer) {
+      clearTimeout(bannerTimer);
+    }
+    bannerTimer = setTimeout(() => {
+      banner.hidden = true;
+      bannerTimer = null;
+    }, 3000);
+  }
+
+  function saveCompareThread(id, topic = "") {
+    try {
+      const normalized = String(id || "").trim();
+      if (!normalized) {
+        return;
+      }
+      window.localStorage?.setItem(
+        COMPARE_THREAD_STORAGE_KEY,
+        JSON.stringify({
+          id: normalized,
+          topic: String(topic || "").trim(),
+        }),
+      );
+    } catch {
+      // Ignore storage failures.
+    }
+  }
+
+  function loadCompareThread() {
+    try {
+      const raw = window.localStorage?.getItem(COMPARE_THREAD_STORAGE_KEY);
+      const parsed = raw ? JSON.parse(raw) : null;
+      if (!parsed || typeof parsed !== "object") {
+        return null;
+      }
+      const id = String(parsed.id || "").trim();
+      if (!id) {
+        return null;
+      }
+      return {
+        id,
+        topic: String(parsed.topic || "").trim(),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  function clearCompareThreadStorage() {
+    try {
+      window.localStorage?.removeItem(COMPARE_THREAD_STORAGE_KEY);
+    } catch {
+      // Ignore storage failures.
+    }
+  }
+
+  function getCompareThreadId() {
+    return compareThreadId;
+  }
+
+  function getCompareThreadTopic() {
+    return compareThreadTopic;
+  }
+
+  function setCompareLastSeq(seq) {
+    const value = typeof seq === "function" ? seq(compareLastSeq) : seq;
+    compareLastSeq = Number.isFinite(value) ? value : 0;
+  }
+
+  function getCompareLastSeq() {
+    return compareLastSeq;
+  }
+
+  function isCompareMode() {
+    return Boolean(compareThreadId);
+  }
+
+  function getMessageTargets(target = TARGET_PRIMARY) {
+    if (target === TARGET_COMPARE) {
+      return {
+        messagesEl: document.getElementById("compare-messages"),
+        sysPromptEl: document.getElementById("compare-sys-prompt-area"),
+        messagesScrollEl: document.getElementById("compare-messages-scroll"),
+      };
+    }
+    return {
+      messagesEl: document.getElementById("messages"),
+      sysPromptEl: document.getElementById("sys-prompt-area"),
+      messagesScrollEl: document.getElementById("messages-scroll"),
+    };
+  }
+
+  function applyCompareLayout(active) {
+    const main = document.getElementById("main");
+    const comparePanel = document.getElementById("compare-panel");
+    if (main) {
+      main.classList.toggle("compare-mode", active);
+    }
+    if (comparePanel) {
+      comparePanel.hidden = !active;
+    }
+  }
+
+  function updateComparePanelTitle(topic) {
+    const titleEl = document.getElementById("compare-panel-title");
+    if (titleEl) {
+      const label = String(topic || compareThreadTopic || compareThreadId || "Compare").trim();
+      titleEl.textContent = label ? `Compare: ${label}` : "Compare";
+    }
+  }
+
+  function clearComparePanelDom() {
+    const compareMessages = document.getElementById("compare-messages");
+    const compareSys = document.getElementById("compare-sys-prompt-area");
+    if (compareMessages) {
+      compareMessages.innerHTML = "";
+    }
+    if (compareSys) {
+      compareSys.innerHTML = "";
+    }
+  }
+
+  function shouldCompareOnShiftClick(activeId, targetId, shiftKey) {
+    const active = String(activeId || "").trim();
+    const target = String(targetId || "").trim();
+    return Boolean(shiftKey && active && target && active !== target);
+  }
+
+  function shouldRefreshCompare(eventThreadId, compareId = compareThreadId) {
+    const eventId = String(eventThreadId || "").trim();
+    const compare = String(compareId || "").trim();
+    return Boolean(compare && eventId && eventId === compare);
+  }
+
+  async function enterCompare(compareId, deps = {}) {
+    const id = String(compareId || "").trim();
+    const activeThreadId = String(deps.activeThreadId || "").trim();
+    if (!id || !activeThreadId || id === activeThreadId) {
+      return false;
+    }
+    if (!isCompareViewportOk()) {
+      showCompareBlockedBanner();
+      return false;
+    }
+
+    compareThreadId = id;
+    compareThreadTopic = String(deps.topic || "").trim();
+    compareLastSeq = 0;
+    saveCompareThread(id, compareThreadTopic);
+    writeThreadHash({ threadId: activeThreadId, compareId: id });
+    applyCompareLayout(true);
+    updateComparePanelTitle(compareThreadTopic);
+
+    if (typeof deps.onLoadTranscript === "function") {
+      await deps.onLoadTranscript(id);
+    }
+    if (typeof deps.onEnter === "function") {
+      deps.onEnter(id);
+    }
+    return true;
+  }
+
+  async function exitCompare(deps = {}) {
+    const activeThreadId = String(deps.activeThreadId || "").trim();
+    compareThreadId = null;
+    compareThreadTopic = "";
+    compareLastSeq = 0;
+    clearCompareThreadStorage();
+    applyCompareLayout(false);
+    clearComparePanelDom();
+    if (activeThreadId) {
+      writeThreadHash({ threadId: activeThreadId, compareId: null });
+    } else {
+      writeThreadHash({ threadId: null, compareId: null });
+    }
+    if (typeof deps.onExit === "function") {
+      deps.onExit();
+    }
+    return true;
+  }
+
+  window.AcbSplitView = {
+    TARGET_PRIMARY,
+    TARGET_COMPARE,
+    parseThreadHash,
+    writeThreadHash,
+    isCompareViewportOk,
+    showCompareBlockedBanner,
+    saveCompareThread,
+    loadCompareThread,
+    clearCompareThreadStorage,
+    getCompareThreadId,
+    getCompareThreadTopic,
+    setCompareLastSeq,
+    getCompareLastSeq,
+    isCompareMode,
+    getMessageTargets,
+    applyCompareLayout,
+    updateComparePanelTitle,
+    clearComparePanelDom,
+    shouldCompareOnShiftClick,
+    shouldRefreshCompare,
+    enterCompare,
+    exitCompare,
+  };
+})();

--- a/agentchatbus-ts/web-ui/js/shared-sse.js
+++ b/agentchatbus-ts/web-ui/js/shared-sse.js
@@ -15,9 +15,13 @@
   function startSSE(deps) {
     const {
       getActiveThreadId,
+      getCompareThreadId,
       onMsgNew,
       onTranscriptUpdate,
       onMsgEdit,
+      onCompareMsgNew,
+      onCompareTranscriptUpdate,
+      onCompareMsgEdit,
       onThreadEvent,
       onAgentPresence,
       onCliSessionEvent,
@@ -44,10 +48,14 @@
       }
       const p = ev.payload || {};
       const activeThreadId = getActiveThreadId();
+      const compareThreadId = typeof getCompareThreadId === "function" ? getCompareThreadId() : null;
 
       if (ev.type === "msg.new") {
         if (p.thread_id === activeThreadId && onMsgNew) {
           await onMsgNew();
+        }
+        if (compareThreadId && p.thread_id === compareThreadId && onCompareMsgNew) {
+          await onCompareMsgNew();
         }
         if (onThreadEvent) {
           await onThreadEvent();
@@ -58,11 +66,17 @@
         if (p.thread_id === activeThreadId && onTranscriptUpdate) {
           await onTranscriptUpdate();
         }
+        if (compareThreadId && p.thread_id === compareThreadId && onCompareTranscriptUpdate) {
+          await onCompareTranscriptUpdate();
+        }
       }
 
       if (ev.type === "msg.edit") {
         if (p.thread_id === activeThreadId && onMsgEdit) {
           await onMsgEdit(p);
+        }
+        if (compareThreadId && p.thread_id === compareThreadId && onCompareMsgEdit) {
+          await onCompareMsgEdit(p);
         }
       }
 

--- a/agentchatbus-ts/web-ui/js/shared-threads.js
+++ b/agentchatbus-ts/web-ui/js/shared-threads.js
@@ -182,6 +182,7 @@
     threads,
     activeThreadId,
     onSelectThread,
+    onCompareWithCurrent,
     onTogglePin,
     onOpenContextMenu,
     onTagFilter,
@@ -211,6 +212,16 @@
       });
       item.addEventListener("thread-select", (e) => {
         const d = e.detail || {};
+        if (
+          d.shiftKey &&
+          activeThreadId &&
+          d.id &&
+          d.id !== activeThreadId &&
+          typeof onCompareWithCurrent === "function"
+        ) {
+          onCompareWithCurrent(d.id, d.topic, d.status);
+          return;
+        }
         onSelectThread(d.id, d.topic, d.status);
       });
       item.addEventListener("thread-context", (e) => {
@@ -253,6 +264,7 @@
     onActiveThreadStatus,
     resetThreadSelection,
     onSelectThread,
+    onCompareWithCurrent,
     onTogglePin,
     onOpenContextMenu,
     onTagFilter,
@@ -260,6 +272,7 @@
     esc,
     timeAgo,
     updateThreadFilterButton,
+    onThreadsRefreshed,
   }) {
     const response = (await api("/api/threads?include_archived=1")) || { threads: [] };
     cachedAllThreads = sortThreadsForDisplay(decorateThreads((response && response.threads) || []));
@@ -281,6 +294,7 @@
       threads,
       activeThreadId,
       onSelectThread,
+      onCompareWithCurrent,
       onTogglePin,
       onOpenContextMenu,
       onTagFilter,
@@ -291,6 +305,9 @@
     });
 
     updateThreadFilterButton();
+    if (typeof onThreadsRefreshed === "function") {
+      onThreadsRefreshed(cachedAllThreads);
+    }
   }
 
   function normalizeThreadStatus(value) {
@@ -303,6 +320,7 @@
 
     const menu = document.getElementById("thread-context-menu");
     const renameBtn = document.getElementById("ctx-rename");
+    const compareBtn = document.getElementById("ctx-compare");
     const archiveBtn = document.getElementById("ctx-archive");
     const unarchiveBtn = document.getElementById("ctx-unarchive");
     const closeBtn = document.getElementById("ctx-close");
@@ -322,6 +340,12 @@
     pinBtn.textContent = thread?.isPinned ? "📍 Unpin" : "📌 Pin";
     deleteBtn.disabled = adModeEnabled;
     deleteBtn.textContent = adModeEnabled ? "🗑️ Delete (disabled by show_ad)" : "🗑️ Delete";
+
+    const activeThreadId = String(options.activeThreadId || "").trim();
+    if (compareBtn) {
+      const canCompare = activeThreadId && String(thread?.id || "").trim() !== activeThreadId;
+      compareBtn.style.display = canCompare ? "block" : "none";
+    }
 
     if (thread.status === "archived") {
       archiveBtn.style.display = "none";
@@ -699,12 +723,17 @@ Task: After entering, stand by. Human programmers may need to publish requiremen
     await refreshThreads();
   }
 
+  function getCachedAllThreads() {
+    return cachedAllThreads.slice();
+  }
+
   window.AcbThreads = {
     toggleThreadFilterPanel,
     hideThreadFilterPanel,
     selectedStatusListFromUI,
     updateThreadFilterButton,
     refreshThreads,
+    getCachedAllThreads,
     openThreadContextMenu,
     hideThreadContextMenu,
     closeThread,

--- a/frontend/src/__tests__/split-view.test.js
+++ b/frontend/src/__tests__/split-view.test.js
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import '../../../web-ui/js/shared-split-view.js';
+
+const {
+  parseThreadHash,
+  writeThreadHash,
+  shouldCompareOnShiftClick,
+  shouldRefreshCompare,
+  isCompareViewportOk,
+  saveCompareThread,
+  loadCompareThread,
+  clearCompareThreadStorage,
+  enterCompare,
+  exitCompare,
+  getCompareThreadId,
+  isCompareMode,
+} = window.AcbSplitView;
+
+describe('UI-04 Split-view', () => {
+  beforeEach(() => {
+    history.replaceState(null, '', location.pathname);
+    clearCompareThreadStorage();
+    document.body.innerHTML = `
+      <div id="main"></div>
+      <div id="compare-panel" hidden></div>
+      <div id="compare-banner" hidden></div>
+      <div id="compare-panel-title"></div>
+      <div id="compare-messages"></div>
+      <div id="compare-sys-prompt-area"></div>
+      <div id="compare-messages-scroll"></div>
+      <div id="messages"></div>
+      <div id="sys-prompt-area"></div>
+      <div id="messages-scroll"></div>
+    `;
+  });
+
+  afterEach(() => {
+    history.replaceState(null, '', location.pathname);
+    clearCompareThreadStorage();
+    vi.restoreAllMocks();
+  });
+
+  describe('parseThreadHash / writeThreadHash', () => {
+    it('parses thread-only hash', () => {
+      expect(parseThreadHash('#thread=abc-123')).toEqual({
+        threadId: 'abc-123',
+        compareId: '',
+      });
+    });
+
+    it('parses thread and compare params', () => {
+      expect(parseThreadHash('#thread=abc&compare=xyz')).toEqual({
+        threadId: 'abc',
+        compareId: 'xyz',
+      });
+    });
+
+    it('parses encoded ids without double-decoding', () => {
+      history.replaceState(null, '', '#thread=id%20with%20spaces&compare=other%2Bid');
+      expect(parseThreadHash()).toEqual({
+        threadId: 'id with spaces',
+        compareId: 'other+id',
+      });
+    });
+
+    it('returns empty ids for empty hash', () => {
+      expect(parseThreadHash('')).toEqual({ threadId: '', compareId: '' });
+      expect(parseThreadHash('#')).toEqual({ threadId: '', compareId: '' });
+    });
+
+    it('writes thread-only hash', () => {
+      writeThreadHash({ threadId: 'abc-123', compareId: null });
+      expect(location.hash).toBe('#thread=abc-123');
+    });
+
+    it('writes thread and compare hash', () => {
+      writeThreadHash({ threadId: 'abc', compareId: 'xyz' });
+      expect(location.hash).toBe('#thread=abc&compare=xyz');
+    });
+
+    it('clears hash when both ids are empty', () => {
+      history.replaceState(null, '', '#thread=old');
+      writeThreadHash({ threadId: null, compareId: null });
+      expect(location.hash).toBe('');
+    });
+
+    it('does not throw on malformed percent sequences', () => {
+      expect(() => parseThreadHash('#thread=abc%')).not.toThrow();
+    });
+  });
+
+  describe('compare localStorage', () => {
+    it('saves and loads compare thread', () => {
+      saveCompareThread('thread-b', 'Topic B');
+      expect(loadCompareThread()).toEqual({ id: 'thread-b', topic: 'Topic B' });
+    });
+
+    it('clears compare thread storage', () => {
+      saveCompareThread('thread-b', 'Topic B');
+      clearCompareThreadStorage();
+      expect(loadCompareThread()).toBeNull();
+    });
+  });
+
+  describe('enterCompare guards', () => {
+    it('rejects compare when id matches active thread', async () => {
+      const result = await enterCompare('same-id', {
+        activeThreadId: 'same-id',
+        onLoadTranscript: vi.fn(),
+      });
+      expect(result).toBe(false);
+      expect(isCompareMode()).toBe(false);
+    });
+
+    it('enters compare for distinct ids when viewport is wide enough', async () => {
+      vi.spyOn(window.AcbSplitView, 'isCompareViewportOk').mockReturnValue(true);
+      const onLoadTranscript = vi.fn().mockResolvedValue(undefined);
+      const result = await enterCompare('compare-id', {
+        activeThreadId: 'primary-id',
+        topic: 'Compare topic',
+        onLoadTranscript,
+      });
+      expect(result).toBe(true);
+      expect(getCompareThreadId()).toBe('compare-id');
+      expect(onLoadTranscript).toHaveBeenCalledWith('compare-id');
+      expect(location.hash).toBe('#thread=primary-id&compare=compare-id');
+    });
+  });
+
+  describe('exitCompare', () => {
+    it('clears compare state and hash compare param', async () => {
+      vi.spyOn(window.AcbSplitView, 'isCompareViewportOk').mockReturnValue(true);
+      await enterCompare('compare-id', {
+        activeThreadId: 'primary-id',
+        onLoadTranscript: vi.fn().mockResolvedValue(undefined),
+      });
+      await exitCompare({ activeThreadId: 'primary-id' });
+      expect(isCompareMode()).toBe(false);
+      expect(location.hash).toBe('#thread=primary-id');
+      expect(loadCompareThread()).toBeNull();
+    });
+  });
+
+  describe('shift-click routing helper', () => {
+    it('returns true only for shift-click on a different active thread', () => {
+      expect(shouldCompareOnShiftClick('a', 'b', true)).toBe(true);
+      expect(shouldCompareOnShiftClick('a', 'a', true)).toBe(false);
+      expect(shouldCompareOnShiftClick('a', 'b', false)).toBe(false);
+      expect(shouldCompareOnShiftClick('', 'b', true)).toBe(false);
+    });
+  });
+
+  describe('shouldRefreshCompare', () => {
+    it('matches compare thread id only', () => {
+      expect(shouldRefreshCompare('compare-1', 'compare-1')).toBe(true);
+      expect(shouldRefreshCompare('other', 'compare-1')).toBe(false);
+      expect(shouldRefreshCompare('compare-1', '')).toBe(false);
+    });
+  });
+
+  describe('viewport guard', () => {
+    it('reports narrow viewport as blocked', () => {
+      const originalInnerWidth = window.innerWidth;
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        value: 800,
+      });
+      expect(isCompareViewportOk()).toBe(false);
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        value: originalInnerWidth,
+      });
+    });
+  });
+});

--- a/frontend/src/__tests__/thread-deeplinks.test.js
+++ b/frontend/src/__tests__/thread-deeplinks.test.js
@@ -1,66 +1,51 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import '../../../web-ui/js/shared-split-view.js';
 
-/**
- * UI-11 - Thread Deeplinks (hash-based)
- *
- * Tests for the three behaviours added to index.html:
- *   1. selectThread writes #thread=<id> to location.hash
- *   2. restoreThreadFromHash reads hash at boot and calls selectThread via GET /api/threads list
- *   3. hashchange listener calls selectThread when hash changes
- *
- * NOTE: GET /api/threads/{id} does not exist in the ACB API.
- * Restoration uses GET /api/threads?include_archived=1&limit=500 and filters by id client-side.
- */
+const { parseThreadHash, writeThreadHash } = window.AcbSplitView;
 
-// ---------------------------------------------------------------------------
-// Helpers extracted from index.html (same logic, testable in isolation)
-// ---------------------------------------------------------------------------
-
-function makeDeeplinkHelpers({ api, selectThread }) {
-  function writeHashOnSelect(id) {
-    history.replaceState(null, '', '#thread=' + encodeURIComponent(id));
-  }
-
-  async function restoreThreadFromHash() {
-    const m = location.hash.match(/^#thread=(.+)$/);
-    if (!m) return;
-    const id = decodeURIComponent(m[1]);
+function makeDeeplinkHelpers({ api, selectThread, enterCompare }) {
+  async function restoreFromHash() {
+    const { threadId, compareId } = parseThreadHash();
+    if (!threadId) {
+      return;
+    }
     try {
-      const response = await api(`/api/threads?include_archived=1&limit=500`);
-      const t = (response.threads || []).find((th) => th.id === id);
-      if (t) selectThread(t.id, t.topic, t.status);
-      else history.replaceState(null, '', location.pathname);
-    } catch (_) {
-      history.replaceState(null, '', location.pathname);
+      const response = await api('/api/threads?include_archived=1&limit=500');
+      const thread = (response.threads || []).find((item) => item.id === threadId);
+      if (!thread) {
+        writeThreadHash({ threadId: null, compareId: compareId || null });
+        return;
+      }
+      await selectThread(thread.id, thread.topic, thread.status);
+      const normalizedCompareId = String(compareId || '').trim();
+      if (
+        normalizedCompareId &&
+        normalizedCompareId !== thread.id &&
+        typeof enterCompare === 'function'
+      ) {
+        const compareThread = (response.threads || []).find((item) => item.id === normalizedCompareId);
+        if (compareThread) {
+          await enterCompare(compareThread.id, compareThread.topic);
+        }
+      }
+    } catch {
+      writeThreadHash({ threadId: null, compareId: null });
     }
   }
 
   function attachHashChangeListener() {
-    window.addEventListener('hashchange', async () => {
-      const m = location.hash.match(/^#thread=(.+)$/);
-      if (!m) return;
-      const id = decodeURIComponent(m[1]);
-      try {
-        const response = await api(`/api/threads?include_archived=1&limit=500`);
-        const t = (response.threads || []).find((th) => th.id === id);
-        if (t) selectThread(t.id, t.topic, t.status);
-        else history.replaceState(null, '', location.pathname);
-      } catch (_) {
-        history.replaceState(null, '', location.pathname);
-      }
+    window.addEventListener('hashchange', () => {
+      void restoreFromHash();
     });
   }
 
-  return { writeHashOnSelect, restoreThreadFromHash, attachHashChangeListener };
+  return { restoreFromHash, attachHashChangeListener, writeHashOnSelect: writeThreadHash };
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
-describe('UI-11 Thread Deeplinks', () => {
+describe('UI-11/UI-04 Thread Deeplinks', () => {
   let apiMock;
   let selectThreadMock;
+  let enterCompareMock;
   let helpers;
 
   const THREAD_LIST = {
@@ -75,10 +60,13 @@ describe('UI-11 Thread Deeplinks', () => {
 
   beforeEach(() => {
     apiMock = vi.fn();
-    selectThreadMock = vi.fn();
-    helpers = makeDeeplinkHelpers({ api: apiMock, selectThread: selectThreadMock });
-
-    // Reset hash before each test
+    selectThreadMock = vi.fn().mockResolvedValue(undefined);
+    enterCompareMock = vi.fn().mockResolvedValue(undefined);
+    helpers = makeDeeplinkHelpers({
+      api: apiMock,
+      selectThread: selectThreadMock,
+      enterCompare: enterCompareMock,
+    });
     history.replaceState(null, '', location.pathname);
   });
 
@@ -87,84 +75,71 @@ describe('UI-11 Thread Deeplinks', () => {
     history.replaceState(null, '', location.pathname);
   });
 
-  // -------------------------------------------------------------------------
-  // 1. writeHashOnSelect
-  // -------------------------------------------------------------------------
-  describe('writeHashOnSelect()', () => {
+  describe('writeHashOnSelect', () => {
     it('sets location.hash to #thread=<id>', () => {
-      helpers.writeHashOnSelect('abc-123');
+      helpers.writeHashOnSelect({ threadId: 'abc-123', compareId: null });
       expect(location.hash).toBe('#thread=abc-123');
     });
 
     it('encodes special characters in the id', () => {
-      helpers.writeHashOnSelect('id with spaces');
-      expect(location.hash).toBe('#thread=id%20with%20spaces');
+      helpers.writeHashOnSelect({ threadId: 'id with spaces', compareId: null });
+      expect(location.hash).toBe('#thread=id+with+spaces');
+    });
+
+    it('writes compare param when provided', () => {
+      helpers.writeHashOnSelect({ threadId: 'abc', compareId: 'xyz' });
+      expect(location.hash).toBe('#thread=abc&compare=xyz');
     });
   });
 
-  // -------------------------------------------------------------------------
-  // 2. restoreThreadFromHash — uses GET /api/threads list
-  // -------------------------------------------------------------------------
-  describe('restoreThreadFromHash()', () => {
-    it('calls api with list endpoint and selectThread when hash contains a valid thread id', async () => {
+  describe('restoreFromHash', () => {
+    it('calls api and selectThread when hash contains a valid thread id', async () => {
       apiMock.mockResolvedValue(THREAD_LIST);
       history.replaceState(null, '', '#thread=abc-123');
 
-      await helpers.restoreThreadFromHash();
+      await helpers.restoreFromHash();
 
       expect(apiMock).toHaveBeenCalledWith('/api/threads?include_archived=1&limit=500');
       expect(selectThreadMock).toHaveBeenCalledWith('abc-123', 'My Thread', 'active');
+      expect(enterCompareMock).not.toHaveBeenCalled();
+    });
+
+    it('restores compare thread when hash includes compare param', async () => {
+      apiMock.mockResolvedValue(THREAD_LIST);
+      history.replaceState(null, '', '#thread=abc-123&compare=xyz-456');
+
+      await helpers.restoreFromHash();
+
+      expect(selectThreadMock).toHaveBeenCalledWith('abc-123', 'My Thread', 'active');
+      expect(enterCompareMock).toHaveBeenCalledWith('xyz-456', 'Another Thread');
+    });
+
+    it('does not treat compare param as part of thread id', async () => {
+      apiMock.mockResolvedValue(THREAD_LIST);
+      history.replaceState(null, '', '#thread=abc-123&compare=xyz-456');
+
+      await helpers.restoreFromHash();
+
+      expect(selectThreadMock).not.toHaveBeenCalledWith('abc-123&compare=xyz-456', expect.anything(), expect.anything());
     });
 
     it('does nothing when hash is absent', async () => {
-      await helpers.restoreThreadFromHash();
-
+      await helpers.restoreFromHash();
       expect(apiMock).not.toHaveBeenCalled();
       expect(selectThreadMock).not.toHaveBeenCalled();
     });
 
-    it('does nothing when hash has a different format', async () => {
-      history.replaceState(null, '', '#something-else');
-
-      await helpers.restoreThreadFromHash();
-
-      expect(apiMock).not.toHaveBeenCalled();
-      expect(selectThreadMock).not.toHaveBeenCalled();
-    });
-
-    it('clears hash silently when thread id is not found in list', async () => {
+    it('clears primary hash when thread id is not found', async () => {
       apiMock.mockResolvedValue({ threads: [], total: 0, has_more: false, next_cursor: null });
-      history.replaceState(null, '', '#thread=unknown-id');
+      history.replaceState(null, '', '#thread=unknown-id&compare=xyz-456');
 
-      await helpers.restoreThreadFromHash();
-
-      expect(selectThreadMock).not.toHaveBeenCalled();
-      expect(location.hash).toBe('');
-    });
-
-    it('clears hash silently when api throws', async () => {
-      apiMock.mockRejectedValue(new Error('Network error'));
-      history.replaceState(null, '', '#thread=abc-123');
-
-      await helpers.restoreThreadFromHash();
+      await helpers.restoreFromHash();
 
       expect(selectThreadMock).not.toHaveBeenCalled();
-      expect(location.hash).toBe('');
-    });
-
-    it('handles missing threads array in api response gracefully', async () => {
-      apiMock.mockResolvedValue({});
-      history.replaceState(null, '', '#thread=abc-123');
-
-      await helpers.restoreThreadFromHash();
-
-      expect(selectThreadMock).not.toHaveBeenCalled();
+      expect(location.hash).toBe('#compare=xyz-456');
     });
   });
 
-  // -------------------------------------------------------------------------
-  // 3. hashchange listener
-  // -------------------------------------------------------------------------
   describe('hashchange listener', () => {
     it('calls api and selectThread when hashchange fires with a valid thread hash', async () => {
       apiMock.mockResolvedValue(THREAD_LIST);
@@ -173,37 +148,22 @@ describe('UI-11 Thread Deeplinks', () => {
       history.replaceState(null, '', '#thread=xyz-456');
       window.dispatchEvent(new HashChangeEvent('hashchange'));
 
-      // Wait for the async handler to settle
-      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(apiMock).toHaveBeenCalledWith('/api/threads?include_archived=1&limit=500');
       expect(selectThreadMock).toHaveBeenCalledWith('xyz-456', 'Another Thread', 'closed');
     });
 
-    it('clears hash when thread not found during hashchange', async () => {
-      apiMock.mockResolvedValue({ threads: [] });
+    it('restores compare when hash updated with compare param', async () => {
+      apiMock.mockResolvedValue(THREAD_LIST);
       helpers.attachHashChangeListener();
 
-      history.replaceState(null, '', '#thread=bad-id');
+      history.replaceState(null, '', '#thread=abc-123&compare=xyz-456');
       window.dispatchEvent(new HashChangeEvent('hashchange'));
 
-      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
-      expect(selectThreadMock).not.toHaveBeenCalled();
-      expect(location.hash).toBe('');
-    });
-
-    it('clears hash when api throws during hashchange', async () => {
-      apiMock.mockRejectedValue(new Error('404'));
-      helpers.attachHashChangeListener();
-
-      history.replaceState(null, '', '#thread=bad-id');
-      window.dispatchEvent(new HashChangeEvent('hashchange'));
-
-      await new Promise((r) => setTimeout(r, 0));
-
-      expect(selectThreadMock).not.toHaveBeenCalled();
-      expect(location.hash).toBe('');
+      expect(enterCompareMock).toHaveBeenCalledWith('xyz-456', 'Another Thread');
     });
   });
 });

--- a/web-ui/css/main.css
+++ b/web-ui/css/main.css
@@ -799,6 +799,124 @@ body[data-theme="light"] .thread-item .ti-pin-btn {
   min-height: 0;
 }
 
+#main-panels {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+#main.compare-mode #main-panels {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 0;
+}
+
+#primary-panel {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+.compare-banner {
+  flex-shrink: 0;
+  padding: 8px 16px;
+  font-size: 13px;
+  text-align: center;
+  color: var(--text-2);
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border);
+}
+
+.compare-panel {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  border-left: 1px solid var(--border);
+  background: var(--surface-1);
+}
+
+.compare-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 16px;
+  height: 52px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.compare-panel-title {
+  flex: 1;
+  min-width: 0;
+  font-size: 14px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.compare-panel-close {
+  flex-shrink: 0;
+  padding: 6px 12px;
+  font-size: 12px;
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-1);
+  cursor: pointer;
+}
+
+.compare-panel-close:hover {
+  background: var(--surface-2);
+}
+
+.compare-messages-wrap {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+}
+
+#compare-sys-prompt-area {
+  flex-shrink: 0;
+}
+
+.compare-chat-body {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  display: flex;
+}
+
+.compare-messages-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 16px;
+}
+
+#compare-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+@media (max-width: 900px) {
+  #main.compare-mode #main-panels {
+    display: flex;
+    flex-direction: column;
+  }
+
+  #main.compare-mode .compare-panel {
+    display: none !important;
+  }
+}
+
 /* Thread header */
 #thread-header {
   padding: 0 20px;

--- a/web-ui/index.html
+++ b/web-ui/index.html
@@ -10,7 +10,7 @@
   <link
     href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
     rel="stylesheet" />
-  <link rel="stylesheet" href="/static/css/main.css?v=30" />
+  <link rel="stylesheet" href="/static/css/main.css?v=31" />
   <link rel="stylesheet" href="/static/vendor/xterm/css/xterm.css" />
 </head>
 
@@ -88,6 +88,10 @@
     <div id="main">
       <acb-thread-header></acb-thread-header>
 
+      <div id="compare-banner" class="compare-banner" hidden role="status" aria-live="polite"></div>
+
+      <div id="main-panels">
+        <div id="primary-panel">
       <!-- UI-02: Search bar -->
       <div id="search-bar" role="search" aria-label="Search messages">
         <div class="search-bar-row">
@@ -162,6 +166,23 @@
           <div id="agent-status-info">ℹ️</div>
         </div>
       </div>
+        </div>
+
+        <div id="compare-panel" class="compare-panel" hidden>
+          <div class="compare-panel-header">
+            <h3 id="compare-panel-title" class="compare-panel-title">Compare</h3>
+            <button id="compare-panel-close" type="button" class="compare-panel-close" aria-label="Close compare view">Close</button>
+          </div>
+          <div id="compare-messages-wrap" class="compare-messages-wrap">
+            <div id="compare-sys-prompt-area"></div>
+            <div id="compare-chat-body" class="compare-chat-body">
+              <div id="compare-messages-scroll" class="compare-messages-scroll">
+                <div id="compare-messages"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 
@@ -179,7 +200,7 @@
   <script src="/static/js/shared-theme.js?v=2"></script>
   <script src="/static/js/shared-utils.js?v=3"></script>
   <script src="/static/js/shared-message-renderer.js?v=5"></script>
-  <script src="/static/js/shared-sse.js?v=3"></script>
+  <script src="/static/js/shared-sse.js?v=4"></script>
   <script src="/static/vendor/xterm/lib/xterm.js"></script>
   <script src="/static/vendor/xterm-addon-fit/lib/addon-fit.js"></script>
   <script src="/static/js/shared-cli-sessions.js?v=18"></script>
@@ -190,18 +211,19 @@
   <script src="/static/js/components/acb-filter-actions.js?v=2"></script>
   <script src="/static/js/components/acb-filter-row.js?v=2"></script>
   <script src="/static/js/components/acb-thread-filter-shell.js?v=2"></script>
-  <script src="/static/js/components/acb-thread-context-menu.js?v=2"></script>
+  <script src="/static/js/components/acb-thread-context-menu.js?v=3"></script>
   <script src="/static/js/components/acb-thread-header.js?v=7"></script>
-  <script src="/static/js/components/acb-thread-item.js?v=3"></script>
+  <script src="/static/js/components/acb-thread-item.js?v=4"></script>
   <script src="/static/js/components/acb-message-tail-meta.js?v=1"></script>
   <script src="/static/js/components/acb-admin-switch-card.js?v=4"></script>
   <script src="/static/js/components/acb-compose-shell.js?v=3"></script>
   <script src="/static/js/components/acb-agent-status-shell.js?v=3"></script>
-  <script src="/static/js/shared-threads.js?v=8"></script>
+  <script src="/static/js/shared-split-view.js?v=1"></script>
+  <script src="/static/js/shared-threads.js?v=9"></script>
   <script src="/static/js/shared-agent-status.js?v=2"></script>
   <script src="/static/js/components/acb-agent-status-item.js?v=2"></script>
   <script src="/static/js/shared-agents.js?v=4"></script>
-  <script src="/static/js/shared-chat.js?v=7"></script>
+  <script src="/static/js/shared-chat.js?v=8"></script>
   <script src="/static/js/shared-nav-sidebar.js?v=1"></script>
   <script src="/static/js/shared-tooltip.js?v=2"></script>
   <script src="/static/js/components/acb-confirm-dialog.js?v=2"></script>
@@ -377,19 +399,7 @@
       if (window.AcbSearch) window.AcbSearch.init();
       await syncShowAdPolicy();
       await refreshThreadSidebarData();
-      const storedActiveThread = loadStoredActiveThread();
-      if (storedActiveThread?.id) {
-        try {
-          await selectThread(
-            storedActiveThread.id,
-            storedActiveThread.topic || storedActiveThread.id,
-            storedActiveThread.status || 'discuss',
-          );
-        } catch {
-          clearStoredActiveThread();
-          resetThreadSelection();
-        }
-      }
+      await restoreBootThreadSelection();
       updateOnlinePresence();
       startSSE();
       setInterval(refreshThreadSidebarData, 10000);
@@ -425,8 +435,29 @@
       hideAgentTooltip();
     });
     document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape') hideThreadContextMenu();
+      if (e.key !== 'Escape') {
+        return;
+      }
+      const menu = document.getElementById('thread-context-menu');
+      if (menu?.classList.contains('visible')) {
+        hideThreadContextMenu();
+        return;
+      }
+      if (window.AcbSplitView?.isCompareMode()) {
+        exitCompare();
+      }
     });
+    window.addEventListener('hashchange', () => {
+      void handleThreadHashChange();
+    });
+
+    const comparePanelCloseBtn = document.getElementById('compare-panel-close');
+    if (comparePanelCloseBtn) {
+      comparePanelCloseBtn.addEventListener('click', () => {
+        exitCompare();
+      });
+    }
+
     window.addEventListener('resize', () => {
       hideThreadContextMenu();
       hideAgentTooltip();
@@ -1035,9 +1066,13 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
     function startSSE() {
       return window.AcbSSE.startSSE({
         getActiveThreadId: () => activeThreadId,
+        getCompareThreadId: () => window.AcbSplitView?.getCompareThreadId() || null,
         onMsgNew: async () => loadNewMessages(),
         onTranscriptUpdate: async () => reloadTranscript(),
         onMsgEdit: async (message) => applyEditedMessage(message),
+        onCompareMsgNew: async () => loadCompareNewMessages(),
+        onCompareTranscriptUpdate: async () => reloadCompareTranscript(),
+        onCompareMsgEdit: async (message) => applyCompareEditedMessage(message),
         onThreadEvent: async () => refreshThreads(),
         onAgentPresence: async () => refreshThreadSidebarData(),
         onCliSessionEvent: async (event) => {
@@ -1093,6 +1128,8 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
         },
         resetThreadSelection,
         onSelectThread: selectThread,
+        onCompareWithCurrent,
+        onThreadsRefreshed: (threads) => ensureCompareThreadStillExists(threads),
         onTogglePin: async (threadId, pinned) => {
           window.AcbThreads.setThreadPinned(threadId, pinned);
           await refreshThreads();
@@ -1188,7 +1225,16 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
     async function selectThread(id, topic, status, initialSyncContext = null) {
       // Close mobile sidebar when selecting thread
       closeMobileSidebar();
+      if (window.AcbSplitView?.getCompareThreadId() === id) {
+        await exitCompare();
+      }
       saveStoredActiveThread({ id, topic, status });
+      if (window.AcbSplitView) {
+        window.AcbSplitView.writeThreadHash({
+          threadId: id,
+          compareId: window.AcbSplitView.getCompareThreadId() || null,
+        });
+      }
       if (window.AcbCliSessions) {
         window.AcbCliSessions.restoreThreadFromCache?.(id);
       }
@@ -1224,6 +1270,230 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
     }
     // Expose globally for AcbSearch navigation
     window.selectThread = selectThread;
+
+    function compareScrollBottom(smooth = false) {
+      const box = document.getElementById('compare-messages-scroll');
+      if (!box) return;
+      setTimeout(() => {
+        void box.offsetHeight;
+        if (smooth) {
+          box.scrollTo({ top: box.scrollHeight, behavior: 'smooth' });
+        } else {
+          box.scrollTop = box.scrollHeight;
+        }
+      }, 50);
+    }
+
+    async function loadCompareTranscript(compareId) {
+      const targets = window.AcbSplitView.getMessageTargets(window.AcbSplitView.TARGET_COMPARE);
+      return window.AcbChat.loadTranscript({
+        id: compareId,
+        api,
+        clearThreadParticipants: () => {},
+        rebuildActiveThreadParticipants: () => {},
+        appendBubble: (m) => appendBubble(m, {
+          target: window.AcbSplitView.TARGET_COMPARE,
+          readOnly: true,
+        }),
+        updateOnlinePresence: () => {},
+        updateStatusBar: async () => {},
+        setLastSeq: (s) => window.AcbSplitView.setCompareLastSeq(s),
+        scrollBottom: compareScrollBottom,
+        refreshAdmin: false,
+        clearCliCache: false,
+        messagesEl: targets.messagesEl,
+        sysPromptEl: targets.sysPromptEl,
+        skipCliActivity: true,
+      });
+    }
+
+    async function loadCompareNewMessages() {
+      const compareId = window.AcbSplitView.getCompareThreadId();
+      if (!compareId) return;
+      const targets = window.AcbSplitView.getMessageTargets(window.AcbSplitView.TARGET_COMPARE);
+      return window.AcbChat.loadNewMessagesForThread({
+        threadId: compareId,
+        getLastSeq: () => window.AcbSplitView.getCompareLastSeq(),
+        api,
+        appendBubble: (m) => appendBubble(m, {
+          target: window.AcbSplitView.TARGET_COMPARE,
+          readOnly: true,
+        }),
+        setLastSeq: (fn) => window.AcbSplitView.setCompareLastSeq(fn),
+        scrollBottom: compareScrollBottom,
+        messagesEl: targets.messagesEl,
+        skipPresence: true,
+      });
+    }
+
+    async function reloadCompareTranscript() {
+      const compareId = window.AcbSplitView.getCompareThreadId();
+      if (!compareId) return;
+      const targets = window.AcbSplitView.getMessageTargets(window.AcbSplitView.TARGET_COMPARE);
+      return window.AcbChat.reloadTranscriptForThread({
+        threadId: compareId,
+        api,
+        clearThreadParticipants: () => {},
+        rebuildActiveThreadParticipants: () => {},
+        appendBubble: (m) => appendBubble(m, {
+          target: window.AcbSplitView.TARGET_COMPARE,
+          readOnly: true,
+        }),
+        updateOnlinePresence: () => {},
+        updateStatusBar: async () => {},
+        setLastSeq: (s) => window.AcbSplitView.setCompareLastSeq(s),
+        scrollBottom: compareScrollBottom,
+        messagesEl: targets.messagesEl,
+        sysPromptEl: targets.sysPromptEl,
+        skipCliActivity: true,
+      });
+    }
+
+    async function enterCompare(compareId, topic = '') {
+      if (!window.AcbSplitView || !activeThreadId) {
+        return false;
+      }
+      return window.AcbSplitView.enterCompare(compareId, {
+        activeThreadId,
+        topic,
+        onLoadTranscript: loadCompareTranscript,
+      });
+    }
+
+    async function exitCompare() {
+      if (!window.AcbSplitView) {
+        return false;
+      }
+      return window.AcbSplitView.exitCompare({ activeThreadId });
+    }
+
+    async function onCompareWithCurrent(compareId, topic, status) {
+      void status;
+      if (!window.AcbSplitView?.isCompareViewportOk()) {
+        window.AcbSplitView.showCompareBlockedBanner();
+        return;
+      }
+      await enterCompare(compareId, topic);
+    }
+
+    async function compareThreadFromMenu() {
+      if (!contextMenuThread?.id) return;
+      hideThreadContextMenu();
+      await onCompareWithCurrent(contextMenuThread.id, contextMenuThread.topic, contextMenuThread.status);
+    }
+    window.compareThreadFromMenu = compareThreadFromMenu;
+
+    async function resolveThreadFromList(threadId) {
+      const normalizedId = String(threadId || '').trim();
+      if (!normalizedId) return null;
+      const cached = window.AcbThreads.getCachedAllThreads().find((thread) => thread.id === normalizedId);
+      if (cached) return cached;
+      try {
+        const response = await api('/api/threads?include_archived=1&limit=500');
+        return (response?.threads || []).find((thread) => thread.id === normalizedId) || null;
+      } catch {
+        return null;
+      }
+    }
+
+    async function restoreBootThreadSelection() {
+      if (!window.AcbSplitView) return;
+      const { threadId, compareId } = window.AcbSplitView.parseThreadHash();
+      let bootedPrimary = false;
+
+      if (threadId) {
+        const thread = await resolveThreadFromList(threadId);
+        if (thread) {
+          try {
+            await selectThread(thread.id, thread.topic, thread.status);
+            bootedPrimary = true;
+          } catch {
+            window.AcbSplitView.writeThreadHash({ threadId: null, compareId: null });
+          }
+        } else {
+          window.AcbSplitView.writeThreadHash({ threadId: null, compareId: compareId || null });
+        }
+      }
+
+      if (!bootedPrimary) {
+        const storedActiveThread = loadStoredActiveThread();
+        if (storedActiveThread?.id) {
+          try {
+            await selectThread(
+              storedActiveThread.id,
+              storedActiveThread.topic || storedActiveThread.id,
+              storedActiveThread.status || 'discuss',
+            );
+            bootedPrimary = true;
+          } catch {
+            clearStoredActiveThread();
+            resetThreadSelection();
+          }
+        }
+      }
+
+      if (!bootedPrimary) {
+        return;
+      }
+
+      const hashCompareId = String(compareId || '').trim();
+      if (hashCompareId && hashCompareId !== activeThreadId && window.AcbSplitView.isCompareViewportOk()) {
+        const compareThread = await resolveThreadFromList(hashCompareId);
+        if (compareThread) {
+          await enterCompare(compareThread.id, compareThread.topic);
+          return;
+        }
+      }
+
+      if (!hashCompareId) {
+        const storedCompare = window.AcbSplitView.loadCompareThread();
+        if (storedCompare?.id && storedCompare.id !== activeThreadId && window.AcbSplitView.isCompareViewportOk()) {
+          const compareThread = await resolveThreadFromList(storedCompare.id);
+          if (compareThread) {
+            await enterCompare(compareThread.id, compareThread.topic || storedCompare.topic);
+          }
+        }
+      }
+    }
+
+    async function handleThreadHashChange() {
+      if (!window.AcbSplitView) return;
+      const { threadId, compareId } = window.AcbSplitView.parseThreadHash();
+
+      if (threadId && threadId !== activeThreadId) {
+        const thread = await resolveThreadFromList(threadId);
+        if (thread) {
+          await selectThread(thread.id, thread.topic, thread.status);
+        }
+      }
+
+      const normalizedCompareId = String(compareId || '').trim();
+      if (!normalizedCompareId) {
+        if (window.AcbSplitView.isCompareMode()) {
+          await exitCompare();
+        }
+        return;
+      }
+
+      if (
+        normalizedCompareId !== window.AcbSplitView.getCompareThreadId() &&
+        normalizedCompareId !== activeThreadId
+      ) {
+        const compareThread = await resolveThreadFromList(normalizedCompareId);
+        if (compareThread) {
+          await enterCompare(compareThread.id, compareThread.topic);
+        }
+      }
+    }
+
+    function ensureCompareThreadStillExists(threads) {
+      const compareId = window.AcbSplitView?.getCompareThreadId();
+      if (!compareId) return;
+      const list = Array.isArray(threads) ? threads : [];
+      if (!list.some((thread) => thread.id === compareId)) {
+        void exitCompare();
+      }
+    }
 
     function getThreadSyncContext(threadId = activeThreadId) {
       if (!threadId) return null;
@@ -1290,7 +1560,10 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
     }
 
     function openThreadContextMenu(event, thread) {
-      contextMenuThread = window.AcbThreads.openThreadContextMenu(event, thread, { showAd });
+      contextMenuThread = window.AcbThreads.openThreadContextMenu(event, thread, {
+        showAd,
+        activeThreadId,
+      });
       // 保存右键点击的位置，用于确认对话框定位
       contextMenuThread._clickX = event.clientX;
       contextMenuThread._clickY = event.clientY;
@@ -1418,6 +1691,9 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
     }
 
     function resetThreadSelection() {
+      if (window.AcbSplitView?.isCompareMode()) {
+        void exitCompare();
+      }
       if (activeThreadId) {
         threadSyncContexts.delete(activeThreadId);
       }
@@ -1432,9 +1708,16 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
       document.querySelectorAll('.thread-item').forEach(el => el.classList.remove('active'));
       document.getElementById('thread-header').style.display = 'none';
       document.getElementById('compose').classList.remove('visible');
-      document.getElementById('messages').innerHTML = EMPTY_STATE_TEMPLATE;
-      const sysArea = document.getElementById('sys-prompt-area');
+      const primaryTargets = window.AcbSplitView?.getMessageTargets(window.AcbSplitView?.TARGET_PRIMARY);
+      const messagesEl = primaryTargets?.messagesEl || document.getElementById('messages');
+      if (messagesEl) {
+        messagesEl.innerHTML = EMPTY_STATE_TEMPLATE;
+      }
+      const sysArea = primaryTargets?.sysPromptEl || document.getElementById('sys-prompt-area');
       if (sysArea) sysArea.innerHTML = '';
+      if (window.AcbSplitView) {
+        window.AcbSplitView.writeThreadHash({ threadId: null, compareId: null });
+      }
       if (window.AcbCliSessions) window.AcbCliSessions.renderThread(null);
       updateOnlinePresence();
       updateCloseThreadButton();
@@ -1617,6 +1900,24 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
       setTimeout(() => target.classList.remove('msg-jump-highlight'), 1500);
     };
 
+    function applyCompareEditedMessage(message) {
+      const compareId = window.AcbSplitView?.getCompareThreadId();
+      if (!message?.id || !compareId || message.thread_id !== compareId) {
+        return;
+      }
+      const targets = window.AcbSplitView.getMessageTargets(window.AcbSplitView.TARGET_COMPARE);
+      const root = targets.messagesEl;
+      if (!root) return;
+      const row = root.querySelector(`[data-msg-id="${CSS.escape(String(message.id))}"]`);
+      if (!row || row.classList.contains('msg-editing')) {
+        return;
+      }
+      const bubbleEl = row.querySelector('.bubble-v2');
+      if (!bubbleEl) return;
+      renderMessageBubble(row, bubbleEl, message.content, message.metadata);
+      syncEditedIndicator(row, message);
+    }
+
     // UI-13: event delegation -- intercepts clicks on any .msg-reply-quote in #messages
     document.getElementById('messages')?.addEventListener('click', (e) => {
       const btn = e.target.closest('button.msg-reply-quote');
@@ -1625,14 +1926,21 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
       if (targetId) window.AcbScrollToMsg(targetId);
     });
 
-    function appendBubble(m) {
-      const box = document.getElementById('messages');
+    function appendBubble(m, options = {}) {
+      const targetKey = options.target || window.AcbSplitView?.TARGET_PRIMARY || 'primary';
+      const readOnly = Boolean(options.readOnly);
+      const targets = window.AcbSplitView?.getMessageTargets(targetKey) || {
+        messagesEl: document.getElementById('messages'),
+        sysPromptEl: document.getElementById('sys-prompt-area'),
+      };
+      const box = targets.messagesEl;
+      if (!box) return;
 
       // ---- Deduplication check (also check sys-prompt-area for seq=0) --------
       const messageId = String(m.id ?? '').trim();
       const hasSeq = typeof m.seq === 'number' && Number.isFinite(m.seq);
       const seq = hasSeq ? String(m.seq) : '';
-      const sysPromptArea = document.getElementById('sys-prompt-area');
+      const sysPromptArea = targets.sysPromptEl;
       const escapedMessageId = messageId && window.CSS && typeof window.CSS.escape === 'function'
         ? window.CSS.escape(messageId)
         : messageId;
@@ -1655,7 +1963,7 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
 
         // Frontend fallback: still render legacy human-decision admin switch cards
         // if old messages exist in history.
-        if (metaObj && (
+        if (!readOnly && metaObj && (
           metaObj.ui_type === 'admin_switch_confirmation_required'
           || metaObj.ui_type === 'admin_takeover_confirmation_required'
         )) {
@@ -1772,7 +2080,7 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
           promptBody.appendChild(promptCopyBtn);
 
           // UI-07: system prompt goes into its own full-width area (above chat-body)
-          const sysArea = document.getElementById('sys-prompt-area') || box;
+          const sysArea = targets.sysPromptEl || box;
           sysArea.innerHTML = '';
           sysArea.appendChild(wrapper);
           return;
@@ -1892,7 +2200,7 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
           <button class="msg-copy-btn" title="Copy message" aria-label="Copy message content" onclick="window.AcbCopyMsg(this)">
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
           </button>
-          ${!isSystem ? `<button class="msg-edit-btn toolbar-btn" aria-label="Edit message" onclick="window.AcbMsgEditStart(this)" data-msg-id="${esc(m.id)}" data-author="${esc(m.author)}">
+          ${!isSystem && !readOnly ? `<button class="msg-edit-btn toolbar-btn" aria-label="Edit message" onclick="window.AcbMsgEditStart(this)" data-msg-id="${esc(m.id)}" data-author="${esc(m.author)}">
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
           </button>` : ''}
         </div>
@@ -1941,7 +2249,7 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
 
       // Set rich tooltip for edit button
       const editBtn = row.querySelector('.msg-edit-btn');
-      if (editBtn && window.AcbTooltip) {
+      if (!readOnly && editBtn && window.AcbTooltip) {
         const helpText = `
           <div style="padding: 10px; max-width: 280px; font-size: 13px; line-height: 1.5; color: var(--text-1);">
             <div style="font-weight: 600; margin-bottom: 4px;">Edit message</div>
@@ -1983,30 +2291,33 @@ Note: Thread name is the topic label. Thread ID is the unique identifier.`;
       }
 
       box.appendChild(row);
-      if (isAgentMessage && window.AcbChat?.refreshCliCardsForAuthor) {
+      if (!readOnly && isAgentMessage && window.AcbChat?.refreshCliCardsForAuthor) {
         window.AcbChat.refreshCliCardsForAuthor(String(m.author_id ?? m.author ?? ''));
       }
-      if (isHuman && window.AcbChat?.refreshHumanDeliveryIndicators) {
+      if (!readOnly && isHuman && window.AcbChat?.refreshHumanDeliveryIndicators) {
         window.AcbChat.refreshHumanDeliveryIndicators(window.currentThreadId || null);
       }
-      if (window.AcbNavSidebar) window.AcbNavSidebar.onNewMessage();
+      if (!readOnly && window.AcbNavSidebar) window.AcbNavSidebar.onNewMessage();
 
-      // UI-07: collapse system prompt on first real message
-      const sysArea = document.getElementById('sys-prompt-area');
-      if (sysArea) {
-        const header = sysArea.querySelector('.msg-sys-prompt-header');
-        const body = sysArea.querySelector('.msg-sys-prompt-body');
-        if (header && body && header.getAttribute('aria-expanded') === 'true') {
-          header.setAttribute('aria-expanded', 'false');
-          header.classList.remove('is-expanded');
-          body.classList.add('collapsed');
-          const chevron = header.querySelector('.msg-sys-prompt-chevron');
-          const label = header.querySelector('.msg-sys-prompt-label');
-          if (chevron) chevron.innerHTML = '&#9660;';
-          if (label) label.textContent = 'Thread Instructions (system) — click to expand';
+      // UI-07: collapse system prompt on first real message (primary only)
+      if (!readOnly && targetKey === (window.AcbSplitView?.TARGET_PRIMARY || 'primary')) {
+        const sysArea = targets.sysPromptEl;
+        if (sysArea) {
+          const header = sysArea.querySelector('.msg-sys-prompt-header');
+          const body = sysArea.querySelector('.msg-sys-prompt-body');
+          if (header && body && header.getAttribute('aria-expanded') === 'true') {
+            header.setAttribute('aria-expanded', 'false');
+            header.classList.remove('is-expanded');
+            body.classList.add('collapsed');
+            const chevron = header.querySelector('.msg-sys-prompt-chevron');
+            const label = header.querySelector('.msg-sys-prompt-label');
+            if (chevron) chevron.innerHTML = '&#9660;';
+            if (label) label.textContent = 'Thread Instructions (system) — click to expand';
+          }
         }
       }
     }
+
     // ---- Typing indicator ----------------------------------------------------------------------------------------------------------
     function showTyping(agentId) {
       const box = document.getElementById('messages');

--- a/web-ui/js/components/acb-thread-context-menu.js
+++ b/web-ui/js/components/acb-thread-context-menu.js
@@ -6,6 +6,7 @@
       this.innerHTML = `
         <div id="thread-context-menu" role="menu">
           <button id="ctx-copy-name" class="ctx-item" type="button" role="menuitem" onclick="copyThreadNameFromMenu()">🧵 Copy Thread Name</button>
+          <button id="ctx-compare" class="ctx-item" type="button" role="menuitem" onclick="compareThreadFromMenu()" style="display: none;">🔀 Compare with current</button>
           <hr class="ctx-divider" aria-hidden="true">
           <button id="ctx-rename" class="ctx-item" type="button" role="menuitem" onclick="renameThreadFromMenu()">✏️ Rename</button>
           <button id="ctx-add-tag" class="ctx-item" type="button" role="menuitem" onclick="addTagFromMenu()">🏷️ Add tag…</button>

--- a/web-ui/js/components/acb-thread-item.js
+++ b/web-ui/js/components/acb-thread-item.js
@@ -15,7 +15,7 @@
     connectedCallback() {
       this.style.display = "block";
       if (!this._boundClick) {
-        this._boundClick = () => {
+        this._boundClick = (e) => {
           if (!this._thread) return;
           this.dispatchEvent(
             new CustomEvent("thread-select", {
@@ -24,6 +24,7 @@
                 id: this._thread.id,
                 topic: this._thread.topic,
                 status: this._thread.status,
+                shiftKey: Boolean(e.shiftKey),
               },
             })
           );
@@ -157,6 +158,7 @@
       this.setAttribute('data-thread-id', String(this._thread.id));
       this.setAttribute('role', 'listitem');
       this.setAttribute('aria-current', this._active ? 'true' : 'false');
+      this.title = 'Shift+click to compare with current thread';
       this.innerHTML = `
         <button class="ti-pin-btn${pinned ? " is-pinned" : ""}" type="button" aria-label="${pinned ? "Unpin thread" : "Pin thread"}" title="${pinned ? "Unpin thread" : "Pin thread"}">📌</button>
         ${waitingBadgeHtml}

--- a/web-ui/js/shared-chat.js
+++ b/web-ui/js/shared-chat.js
@@ -787,8 +787,11 @@
     scrollBottom,
     refreshAdmin = true,
     clearCliCache = true,
+    messagesEl = null,
+    sysPromptEl = null,
+    skipCliActivity = false,
   }) {
-    const box = document.getElementById("messages");
+    const box = messagesEl || document.getElementById("messages");
     if (!box) {
       return;
     }
@@ -797,24 +800,36 @@
       clearThreadParticipants();
     }
     box.innerHTML = "";
-    clearCliActivityRows(id, clearCliCache);
-    const sysPromptAreaEl = document.getElementById("sys-prompt-area");
-    if (sysPromptAreaEl) sysPromptAreaEl.innerHTML = "";
+    if (!skipCliActivity) {
+      clearCliActivityRows(id, clearCliCache);
+    }
+    const sysPromptAreaEl = sysPromptEl || document.getElementById("sys-prompt-area");
+    if (sysPromptAreaEl) {
+      sysPromptAreaEl.innerHTML = "";
+    }
     box.classList.add("loading-history");
 
     const msgs =
       (await api(`/api/threads/${id}/transcript?after_seq=0&limit=400&include_system_prompt=1`)) ||
       [];
-    rebuildActiveThreadParticipants(msgs);
+    if (typeof rebuildActiveThreadParticipants === "function") {
+      rebuildActiveThreadParticipants(msgs);
+    }
     msgs.forEach(appendBubble);
-    const cachedSessions = getThreadActivityCache(id);
-    if (cachedSessions && !clearCliCache) {
-      for (const session of cachedSessions.values()) {
-        renderCliActivitySession(session, false);
+    if (!skipCliActivity) {
+      const cachedSessions = getThreadActivityCache(id);
+      if (cachedSessions && !clearCliCache) {
+        for (const session of cachedSessions.values()) {
+          renderCliActivitySession(session, false);
+        }
       }
     }
-    updateOnlinePresence();
-    await updateStatusBar();
+    if (typeof updateOnlinePresence === "function") {
+      updateOnlinePresence();
+    }
+    if (typeof updateStatusBar === "function") {
+      await updateStatusBar();
+    }
     if (refreshAdmin) {
       await refreshThreadAdmin(id, api);
     }
@@ -822,7 +837,9 @@
     if (window.AcbMessageRenderer?.renderMermaidBlocks) {
       await window.AcbMessageRenderer.renderMermaidBlocks(box);
     }
-    scrollBottom(false);
+    if (typeof scrollBottom === "function") {
+      scrollBottom(false);
+    }
     box.classList.remove("loading-history");
   }
 
@@ -870,6 +887,63 @@
     });
   }
 
+  async function loadNewMessagesForThread({
+    threadId,
+    getLastSeq,
+    api,
+    getAgentPresenceKey,
+    getAgentDisplayName,
+    recordThreadAgentActivity,
+    appendBubble,
+    updateOnlinePresence,
+    updateStatusBar,
+    setLastSeq,
+    scrollBottom,
+    messagesEl = null,
+    skipPresence = false,
+  }) {
+    const normalizedThreadId = String(threadId || "").trim();
+    if (!normalizedThreadId) {
+      return [];
+    }
+
+    const cursor = getLastSeq();
+    const msgs =
+      (await api(`/api/threads/${normalizedThreadId}/messages?after_seq=${cursor}&limit=100`)) || [];
+
+    if (!skipPresence) {
+      msgs.forEach((m) => {
+        const key = getAgentPresenceKey(m);
+        const label = getAgentDisplayName(m);
+        if (key && typeof recordThreadAgentActivity === "function") {
+          recordThreadAgentActivity(key, label, m.created_at);
+        }
+      });
+    }
+
+    msgs.forEach(appendBubble);
+    if (typeof updateOnlinePresence === "function") {
+      updateOnlinePresence();
+    }
+    if (typeof updateStatusBar === "function") {
+      await updateStatusBar();
+    }
+
+    msgs.forEach((m) => {
+      setLastSeq((prev) => Math.max(prev, m.seq));
+    });
+
+    const box = messagesEl || document.getElementById("messages");
+    if (msgs.length && window.AcbMessageRenderer?.renderMermaidBlocks) {
+      await window.AcbMessageRenderer.renderMermaidBlocks(box);
+    }
+
+    if (msgs.length && typeof scrollBottom === "function") {
+      scrollBottom(true);
+    }
+    return msgs;
+  }
+
   async function loadNewMessages({
     getActiveThreadId,
     getLastSeq,
@@ -910,6 +984,42 @@
     }
 
     if (msgs.length) scrollBottom(true);
+  }
+
+  async function reloadTranscriptForThread({
+    threadId,
+    api,
+    clearThreadParticipants,
+    rebuildActiveThreadParticipants,
+    appendBubble,
+    updateOnlinePresence,
+    updateStatusBar,
+    setLastSeq,
+    scrollBottom,
+    messagesEl = null,
+    sysPromptEl = null,
+    skipCliActivity = false,
+  }) {
+    const normalizedThreadId = String(threadId || "").trim();
+    if (!normalizedThreadId) {
+      return;
+    }
+    await loadTranscript({
+      id: normalizedThreadId,
+      api,
+      clearThreadParticipants,
+      rebuildActiveThreadParticipants,
+      appendBubble,
+      updateOnlinePresence,
+      updateStatusBar,
+      setLastSeq,
+      scrollBottom,
+      refreshAdmin: false,
+      clearCliCache: false,
+      messagesEl,
+      sysPromptEl,
+      skipCliActivity,
+    });
   }
 
   async function reloadTranscript({
@@ -1103,6 +1213,9 @@
     refreshThreadAdmin,
     selectThread,
     reloadTranscript,
+    loadTranscript,
+    loadNewMessagesForThread,
+    reloadTranscriptForThread,
     loadNewMessages,
     sendMessage,
     handleKey,

--- a/web-ui/js/shared-split-view.js
+++ b/web-ui/js/shared-split-view.js
@@ -1,0 +1,251 @@
+(function () {
+  const COMPARE_THREAD_STORAGE_KEY = "acb-compare-thread";
+  const MIN_COMPARE_WIDTH_PX = 900;
+  const TARGET_PRIMARY = "primary";
+  const TARGET_COMPARE = "compare";
+
+  let compareThreadId = null;
+  let compareThreadTopic = "";
+  let compareLastSeq = 0;
+  let bannerTimer = null;
+
+  function parseThreadHash(hash = location.hash) {
+    const body = String(hash || "").replace(/^#/, "");
+    if (!body) {
+      return { threadId: "", compareId: "" };
+    }
+    const params = new URLSearchParams(body.includes("=") ? body : `thread=${body}`);
+    return {
+      threadId: String(params.get("thread") || "").trim(),
+      compareId: String(params.get("compare") || "").trim(),
+    };
+  }
+
+  function writeThreadHash({ threadId, compareId }) {
+    const params = new URLSearchParams();
+    if (threadId) {
+      params.set("thread", threadId);
+    }
+    if (compareId) {
+      params.set("compare", compareId);
+    }
+    const next = params.toString();
+    history.replaceState(null, "", next ? `#${next}` : location.pathname);
+  }
+
+  function isCompareViewportOk() {
+    return window.innerWidth >= MIN_COMPARE_WIDTH_PX;
+  }
+
+  function showCompareBlockedBanner(message = "Compare view needs a wider window") {
+    const banner = document.getElementById("compare-banner");
+    if (!banner) {
+      return;
+    }
+    banner.textContent = message;
+    banner.hidden = false;
+    if (bannerTimer) {
+      clearTimeout(bannerTimer);
+    }
+    bannerTimer = setTimeout(() => {
+      banner.hidden = true;
+      bannerTimer = null;
+    }, 3000);
+  }
+
+  function saveCompareThread(id, topic = "") {
+    try {
+      const normalized = String(id || "").trim();
+      if (!normalized) {
+        return;
+      }
+      window.localStorage?.setItem(
+        COMPARE_THREAD_STORAGE_KEY,
+        JSON.stringify({
+          id: normalized,
+          topic: String(topic || "").trim(),
+        }),
+      );
+    } catch {
+      // Ignore storage failures.
+    }
+  }
+
+  function loadCompareThread() {
+    try {
+      const raw = window.localStorage?.getItem(COMPARE_THREAD_STORAGE_KEY);
+      const parsed = raw ? JSON.parse(raw) : null;
+      if (!parsed || typeof parsed !== "object") {
+        return null;
+      }
+      const id = String(parsed.id || "").trim();
+      if (!id) {
+        return null;
+      }
+      return {
+        id,
+        topic: String(parsed.topic || "").trim(),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  function clearCompareThreadStorage() {
+    try {
+      window.localStorage?.removeItem(COMPARE_THREAD_STORAGE_KEY);
+    } catch {
+      // Ignore storage failures.
+    }
+  }
+
+  function getCompareThreadId() {
+    return compareThreadId;
+  }
+
+  function getCompareThreadTopic() {
+    return compareThreadTopic;
+  }
+
+  function setCompareLastSeq(seq) {
+    const value = typeof seq === "function" ? seq(compareLastSeq) : seq;
+    compareLastSeq = Number.isFinite(value) ? value : 0;
+  }
+
+  function getCompareLastSeq() {
+    return compareLastSeq;
+  }
+
+  function isCompareMode() {
+    return Boolean(compareThreadId);
+  }
+
+  function getMessageTargets(target = TARGET_PRIMARY) {
+    if (target === TARGET_COMPARE) {
+      return {
+        messagesEl: document.getElementById("compare-messages"),
+        sysPromptEl: document.getElementById("compare-sys-prompt-area"),
+        messagesScrollEl: document.getElementById("compare-messages-scroll"),
+      };
+    }
+    return {
+      messagesEl: document.getElementById("messages"),
+      sysPromptEl: document.getElementById("sys-prompt-area"),
+      messagesScrollEl: document.getElementById("messages-scroll"),
+    };
+  }
+
+  function applyCompareLayout(active) {
+    const main = document.getElementById("main");
+    const comparePanel = document.getElementById("compare-panel");
+    if (main) {
+      main.classList.toggle("compare-mode", active);
+    }
+    if (comparePanel) {
+      comparePanel.hidden = !active;
+    }
+  }
+
+  function updateComparePanelTitle(topic) {
+    const titleEl = document.getElementById("compare-panel-title");
+    if (titleEl) {
+      const label = String(topic || compareThreadTopic || compareThreadId || "Compare").trim();
+      titleEl.textContent = label ? `Compare: ${label}` : "Compare";
+    }
+  }
+
+  function clearComparePanelDom() {
+    const compareMessages = document.getElementById("compare-messages");
+    const compareSys = document.getElementById("compare-sys-prompt-area");
+    if (compareMessages) {
+      compareMessages.innerHTML = "";
+    }
+    if (compareSys) {
+      compareSys.innerHTML = "";
+    }
+  }
+
+  function shouldCompareOnShiftClick(activeId, targetId, shiftKey) {
+    const active = String(activeId || "").trim();
+    const target = String(targetId || "").trim();
+    return Boolean(shiftKey && active && target && active !== target);
+  }
+
+  function shouldRefreshCompare(eventThreadId, compareId = compareThreadId) {
+    const eventId = String(eventThreadId || "").trim();
+    const compare = String(compareId || "").trim();
+    return Boolean(compare && eventId && eventId === compare);
+  }
+
+  async function enterCompare(compareId, deps = {}) {
+    const id = String(compareId || "").trim();
+    const activeThreadId = String(deps.activeThreadId || "").trim();
+    if (!id || !activeThreadId || id === activeThreadId) {
+      return false;
+    }
+    if (!isCompareViewportOk()) {
+      showCompareBlockedBanner();
+      return false;
+    }
+
+    compareThreadId = id;
+    compareThreadTopic = String(deps.topic || "").trim();
+    compareLastSeq = 0;
+    saveCompareThread(id, compareThreadTopic);
+    writeThreadHash({ threadId: activeThreadId, compareId: id });
+    applyCompareLayout(true);
+    updateComparePanelTitle(compareThreadTopic);
+
+    if (typeof deps.onLoadTranscript === "function") {
+      await deps.onLoadTranscript(id);
+    }
+    if (typeof deps.onEnter === "function") {
+      deps.onEnter(id);
+    }
+    return true;
+  }
+
+  async function exitCompare(deps = {}) {
+    const activeThreadId = String(deps.activeThreadId || "").trim();
+    compareThreadId = null;
+    compareThreadTopic = "";
+    compareLastSeq = 0;
+    clearCompareThreadStorage();
+    applyCompareLayout(false);
+    clearComparePanelDom();
+    if (activeThreadId) {
+      writeThreadHash({ threadId: activeThreadId, compareId: null });
+    } else {
+      writeThreadHash({ threadId: null, compareId: null });
+    }
+    if (typeof deps.onExit === "function") {
+      deps.onExit();
+    }
+    return true;
+  }
+
+  window.AcbSplitView = {
+    TARGET_PRIMARY,
+    TARGET_COMPARE,
+    parseThreadHash,
+    writeThreadHash,
+    isCompareViewportOk,
+    showCompareBlockedBanner,
+    saveCompareThread,
+    loadCompareThread,
+    clearCompareThreadStorage,
+    getCompareThreadId,
+    getCompareThreadTopic,
+    setCompareLastSeq,
+    getCompareLastSeq,
+    isCompareMode,
+    getMessageTargets,
+    applyCompareLayout,
+    updateComparePanelTitle,
+    clearComparePanelDom,
+    shouldCompareOnShiftClick,
+    shouldRefreshCompare,
+    enterCompare,
+    exitCompare,
+  };
+})();

--- a/web-ui/js/shared-sse.js
+++ b/web-ui/js/shared-sse.js
@@ -15,9 +15,13 @@
   function startSSE(deps) {
     const {
       getActiveThreadId,
+      getCompareThreadId,
       onMsgNew,
       onTranscriptUpdate,
       onMsgEdit,
+      onCompareMsgNew,
+      onCompareTranscriptUpdate,
+      onCompareMsgEdit,
       onThreadEvent,
       onAgentPresence,
       onCliSessionEvent,
@@ -44,10 +48,14 @@
       }
       const p = ev.payload || {};
       const activeThreadId = getActiveThreadId();
+      const compareThreadId = typeof getCompareThreadId === "function" ? getCompareThreadId() : null;
 
       if (ev.type === "msg.new") {
         if (p.thread_id === activeThreadId && onMsgNew) {
           await onMsgNew();
+        }
+        if (compareThreadId && p.thread_id === compareThreadId && onCompareMsgNew) {
+          await onCompareMsgNew();
         }
         if (onThreadEvent) {
           await onThreadEvent();
@@ -58,11 +66,17 @@
         if (p.thread_id === activeThreadId && onTranscriptUpdate) {
           await onTranscriptUpdate();
         }
+        if (compareThreadId && p.thread_id === compareThreadId && onCompareTranscriptUpdate) {
+          await onCompareTranscriptUpdate();
+        }
       }
 
       if (ev.type === "msg.edit") {
         if (p.thread_id === activeThreadId && onMsgEdit) {
           await onMsgEdit(p);
+        }
+        if (compareThreadId && p.thread_id === compareThreadId && onCompareMsgEdit) {
+          await onCompareMsgEdit(p);
         }
       }
 

--- a/web-ui/js/shared-threads.js
+++ b/web-ui/js/shared-threads.js
@@ -182,6 +182,7 @@
     threads,
     activeThreadId,
     onSelectThread,
+    onCompareWithCurrent,
     onTogglePin,
     onOpenContextMenu,
     onTagFilter,
@@ -211,6 +212,16 @@
       });
       item.addEventListener("thread-select", (e) => {
         const d = e.detail || {};
+        if (
+          d.shiftKey &&
+          activeThreadId &&
+          d.id &&
+          d.id !== activeThreadId &&
+          typeof onCompareWithCurrent === "function"
+        ) {
+          onCompareWithCurrent(d.id, d.topic, d.status);
+          return;
+        }
         onSelectThread(d.id, d.topic, d.status);
       });
       item.addEventListener("thread-context", (e) => {
@@ -253,6 +264,7 @@
     onActiveThreadStatus,
     resetThreadSelection,
     onSelectThread,
+    onCompareWithCurrent,
     onTogglePin,
     onOpenContextMenu,
     onTagFilter,
@@ -260,6 +272,7 @@
     esc,
     timeAgo,
     updateThreadFilterButton,
+    onThreadsRefreshed,
   }) {
     const response = (await api("/api/threads?include_archived=1")) || { threads: [] };
     cachedAllThreads = sortThreadsForDisplay(decorateThreads((response && response.threads) || []));
@@ -281,6 +294,7 @@
       threads,
       activeThreadId,
       onSelectThread,
+      onCompareWithCurrent,
       onTogglePin,
       onOpenContextMenu,
       onTagFilter,
@@ -291,6 +305,9 @@
     });
 
     updateThreadFilterButton();
+    if (typeof onThreadsRefreshed === "function") {
+      onThreadsRefreshed(cachedAllThreads);
+    }
   }
 
   function normalizeThreadStatus(value) {
@@ -303,6 +320,7 @@
 
     const menu = document.getElementById("thread-context-menu");
     const renameBtn = document.getElementById("ctx-rename");
+    const compareBtn = document.getElementById("ctx-compare");
     const archiveBtn = document.getElementById("ctx-archive");
     const unarchiveBtn = document.getElementById("ctx-unarchive");
     const closeBtn = document.getElementById("ctx-close");
@@ -322,6 +340,12 @@
     pinBtn.textContent = thread?.isPinned ? "📍 Unpin" : "📌 Pin";
     deleteBtn.disabled = adModeEnabled;
     deleteBtn.textContent = adModeEnabled ? "🗑️ Delete (disabled by show_ad)" : "🗑️ Delete";
+
+    const activeThreadId = String(options.activeThreadId || "").trim();
+    if (compareBtn) {
+      const canCompare = activeThreadId && String(thread?.id || "").trim() !== activeThreadId;
+      compareBtn.style.display = canCompare ? "block" : "none";
+    }
 
     if (thread.status === "archived") {
       archiveBtn.style.display = "none";
@@ -699,12 +723,17 @@ Task: After entering, stand by. Human programmers may need to publish requiremen
     await refreshThreads();
   }
 
+  function getCachedAllThreads() {
+    return cachedAllThreads.slice();
+  }
+
   window.AcbThreads = {
     toggleThreadFilterPanel,
     hideThreadFilterPanel,
     selectedStatusListFromUI,
     updateThreadFilterButton,
     refreshThreads,
+    getCachedAllThreads,
     openThreadContextMenu,
     hideThreadContextMenu,
     closeThread,


### PR DESCRIPTION
## Summary
- Add split-view compare mode: primary thread left (interactive), compare thread right (read-only transcript + system prompt).
- Entry points: context menu "Compare with current", Shift+click sidebar thread, hash deeplink `#thread=<id>&compare=<id>`.
- Live SSE updates on both panes; Escape closes compare after context menu; viewport guard below 900px with banner.

## Test plan
- [x] `frontend` Vitest: `split-view.test.js` + rewritten `thread-deeplinks.test.js` (26 cases)
- [x] `npm run sync:webui` copies assets into `agentchatbus-ts`
- [ ] Manual: context menu compare, Shift+click, cold load `#thread=A&compare=B`, copy URL to new tab
- [ ] Manual: `selectThread` updates `#thread=<id>` without compare mode
- [ ] Manual: SSE live update on compare pane; Escape priority (menu then compare exit)
