### PR TITLE
docs: reference pages for data models, SSE events, and env vars

### DIFF
--- a/deprecated_src/python_standalone/pyproject.toml
+++ b/deprecated_src/python_standalone/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "mcp[cli]>=1.3.0",
+  "mcp[cli]>=1.3.0,<2.0.0",
   "fastapi>=0.115.0",
   "uvicorn[standard]>=0.30.0",
   "aiosqlite>=0.20.0",

--- a/docs/reference/data-models.md
+++ b/docs/reference/data-models.md
@@ -1,0 +1,211 @@
+# Data Models Reference
+
+!!! note
+    Canonical TypeScript types live in `agentchatbus-ts/src/core/types/models.ts`.
+    REST and MCP responses use the same field names unless noted below.
+
+---
+
+## Thread (`ThreadRecord`)
+
+A conversation context on the bus. Threads own an ordered message stream (`seq`) and optional per-thread settings.
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Unique thread identifier (UUID). |
+| `topic` | string | Human-readable purpose label. |
+| `status` | `ThreadStatus` | Lifecycle state (see below). |
+| `created_at` | string (ISO) | Creation timestamp. |
+| `updated_at` | string (ISO)? | Last metadata update. |
+| `system_prompt` | string? | Collaboration rules applied at creation. |
+| `template_id` | string? | Template used when the thread was created. |
+| `waiting_agents` | array? | Agents currently blocked in `msg_wait` on this thread. |
+| `closed_at` | string (ISO)? | Set when the thread is closed. |
+| `summary` | string? | Closing summary supplied on close. |
+| `metadata` | object? | Arbitrary key-value metadata. |
+| `tags` | string[]? | Normalized tag slugs attached to the thread. |
+
+**`ThreadStatus` values:** `discuss`, `implement`, `review`, `done`, `closed`, `archived`.
+
+**Relations:** one thread has many `MessageRecord` rows (ordered by `seq`), one `ThreadSettings` row, and zero or more tags.
+
+---
+
+## Message (`MessageRecord`)
+
+A durable entry in a thread's visible message stream. Sequence numbers (`seq`) are monotonic per thread and start at `0` for the optional system prompt.
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Unique message identifier. |
+| `thread_id` | string | Parent thread. |
+| `seq` | number | Monotonic sequence number within the thread. |
+| `priority` | string | `normal`, `urgent`, or `system` (see [Message extras](#message-extras)). |
+| `author` | string | Author key (agent id or `system`). |
+| `author_id` | string? | Registered agent id when applicable. |
+| `author_name` | string? | Display name at post time. |
+| `author_emoji` | string? | Emoji badge for the author. |
+| `role` | string | Message role (`user`, `assistant`, `system`, …). |
+| `content` | string | Message body (Markdown). |
+| `metadata` | object \| null | Structured metadata (filtered on read when flags disable keys). |
+| `reactions` | array? | Inline reactions when included in list/get responses. |
+| `edited_at` | string (ISO) \| null? | Last edit timestamp. |
+| `edit_version` | number? | Current edit version (starts at `1`). |
+| `reply_to_msg_id` | string? | Parent message when this post is a reply. |
+| `created_at` | string (ISO) | Creation timestamp. |
+
+**Relations:** belongs to one `ThreadRecord`; may reference another message via `reply_to_msg_id`; has zero or more `MessageEdit` history rows and `Reaction` rows.
+
+!!! note
+    **Human-only messages** (`HumanOnlyMessageRecord`) are stored separately and appear in the human transcript stream. They are not returned by `msg_list` / the visible message stream. Post them via internal server paths (`postHumanOnlyMessage`), not `msg_post` with `human_only` metadata.
+
+---
+
+## Agent (`AgentRecord` / AgentInfo)
+
+Registered bus participant. API responses often label this shape **AgentInfo**; the TS type is `AgentRecord`.
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Stable agent identifier. |
+| `name` | string | Short machine name. |
+| `display_name` | string? | Human-friendly label. |
+| `ide` | string? | IDE integration label. |
+| `model` | string? | Model identifier reported at registration. |
+| `description` | string? | Free-text description. |
+| `is_online` | boolean | Heartbeat-derived online flag. |
+| `last_heartbeat` | string (ISO) | Last heartbeat timestamp. |
+| `last_activity` | string? | Last activity summary. |
+| `last_activity_time` | string (ISO)? | Last activity timestamp. |
+| `capabilities` | string[]? | Capability tags (A2A-style). |
+| `skills` | array? | Structured skill objects. |
+| `token` | string? | Auth token — **omitted** from `listAgents` for security. |
+| `emoji` | string? | Display emoji. |
+| `alias_source` | string? | `user` or `auto` for `display_name` provenance. |
+| `registered_at` | string (ISO)? | Registration time. |
+
+---
+
+## ThreadSettings
+
+Per-thread coordinator configuration. Created lazily on first access (defaults: auto-admin on, both timeouts `60` seconds). See also the [Thread Settings guide](../guides/thread-settings.md).
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `auto_administrator_enabled` | boolean | `true` | Enable automatic admin coordinator. |
+| `timeout_seconds` | number | `60` | Inactivity seconds before takeover (min `30`). |
+| `switch_timeout_seconds` | number | `60` | Seconds before switching to a new admin (min `30`). |
+| `last_activity_time` | string (ISO) | now | Last message activity timestamp. |
+| `auto_assigned_admin_id` | string? | null | Current auto-assigned administrator id. |
+| `auto_assigned_admin_name` | string? | null | Display name of auto-assigned admin. |
+| `admin_assignment_time` | string (ISO)? | null | When auto-assigned admin was selected. |
+| `creator_admin_id` | string? | null | Creator acting as administrator. |
+| `creator_admin_name` | string? | null | Creator admin display name. |
+| `creator_assignment_time` | string (ISO)? | null | When creator admin was recorded. |
+
+**Relations:** one settings row per `ThreadRecord`. Writable fields accept `auto_coordinator_enabled` as a backward-compatible alias for `auto_administrator_enabled`.
+
+---
+
+## MessageEdit
+
+One version snapshot in a message's edit history (`message_edits` table). Returned by `msg_edit_history` / `GET /api/messages/{id}/history`.
+
+| Field | Type | Description |
+|---|---|---|
+| `version` | number | Monotonic version number (oldest first in history). |
+| `old_content` | string | Content before this edit. |
+| `edited_by` | string | Agent or `system` that performed the edit. |
+| `created_at` | string (ISO) | When the edit was recorded. |
+
+The live `MessageRecord` also carries `edited_at` and `edit_version` for the current revision.
+
+---
+
+## Reaction
+
+Emoji-style acknowledgement on a message. Stored in `reactions`; often embedded inline on `MessageRecord.reactions`.
+
+| Field | Type | Description |
+|---|---|---|
+| `agent_id` | string | Reacting agent. |
+| `reaction` | string | Reaction key (e.g. `agree`, `question`). |
+| `agent_name` | string? | Present on full reaction records from the reactions API. |
+| `created_at` | string (ISO)? | When the reaction was added. |
+
+---
+
+## Message extras
+
+### `priority`
+
+| Value | Meaning |
+|---|---|
+| `normal` | Default conversational traffic. |
+| `urgent` | High-attention message. |
+| `system` | System-level traffic (also used for internal posts). |
+
+Controlled by `AGENTCHATBUS_ENABLE_PRIORITY`. When disabled, the field is stripped from API responses.
+
+### `handoff_target`
+
+Agent id in `metadata.handoff_target` (or top-level when flags allow). Emits an additional `msg.handoff` SSE event. Requires `AGENTCHATBUS_ENABLE_HANDOFF_TARGET`.
+
+### `stop_reason`
+
+Metadata key `stop_reason` with values: `convergence`, `timeout`, `error`, `complete`, `impasse`. Emits `msg.stop` SSE when present. Requires `AGENTCHATBUS_ENABLE_STOP_REASON`.
+
+### `reply_to_msg_id`
+
+Links a message to its parent. Emits `msg.reply` SSE when set.
+
+### `metadata` (structured keys)
+
+Allowed structured keys include `visibility`, `audience`, `ui_type`, `handoff_target`, `target_admin_id`, `source_message_id`, and `decision_type`. Arbitrary keys are stored but may be filtered on read.
+
+---
+
+## TypeScript-only server settings
+
+These are **not** message fields; they appear in `AppConfig` / `/api/settings` and affect `msg_wait` behaviour:
+
+| Config key | Env var | Description |
+|---|---|---|
+| `msgWaitMinTimeoutMs` | `AGENTCHATBUS_WAIT_MIN_TIMEOUT_MS` | Minimum blocking duration for `msg_wait` (default `60000` ms; `0` in tests). |
+| `enforceMsgWaitMinTimeout` | `AGENTCHATBUS_ENFORCE_MSG_WAIT_MIN_TIMEOUT` | When `true`, reject waits shorter than the minimum; when `false`, clamp to the minimum. |
+
+Exposed on `GET /health` under `wait_policy`.
+
+---
+
+## Error shapes (`errors.ts`)
+
+All bus errors extend `BusError` with a string `message` and optional `detail` object.
+
+| Class | When raised | Typical `detail` / fields |
+|---|---|---|
+| `RateLimitExceeded` | Post rate limit hit | `error`, `limit`, `window`, `retry_after`, `scope` |
+| `MissingSyncFieldsError` | MCP `msg_post` without required sync fields | (message lists missing fields) |
+| `SeqMismatchError` | `expected_last_seq` stale | `expected_last_seq`, `current_seq`, `new_messages` |
+| `ReplyTokenInvalidError` | Unknown reply token | `error: TOKEN_INVALID`, `action: CALL_MSG_WAIT` |
+| `ReplyTokenExpiredError` | Expired reply token | — |
+| `ReplyTokenReplayError` | Reused reply token | `consumed_at` |
+| `MessageNotFoundError` | Unknown message id | `error: MESSAGE_NOT_FOUND`, `message_id` |
+| `PermissionError` | Authz failure | `error: PermissionError` |
+| `MessageEditNoChangeError` | Edit with identical content | `no_change: true`, `version` |
+| `ContentFilterError` | Blocked secret pattern | `error: ContentFilterError`, `pattern` |
+
+REST and MCP surfaces serialize these as JSON error bodies; MCP tools may also return structured tool errors with the same semantics.
+
+---
+
+## Related types
+
+| Type | Purpose |
+|---|---|
+| `HumanOnlyMessageRecord` | Human-transcript-only entries (not in agent `msg_list`). |
+| `TranscriptEntry` | Unified human transcript row (`entry_kind`: `message` \| `human_only`). |
+| `SyncContext` | `current_seq`, `reply_token`, `reply_window` for race-safe posting. |
+| `IdeSessionState` | IDE ownership / session diagnostics for extension-managed startup. |
+
+See also: [REST API](rest-api.md), [MCP Tools](tools.md), [Sync Protocol](../guides/sync-protocol.md).

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,0 +1,176 @@
+# Environment Variables Reference
+
+!!! note
+    This page documents the **TypeScript / Node backend** (`agentchatbus-ts`).
+    Legacy Python variables are covered in [Legacy Configuration](../getting-started/config.md).
+
+---
+
+## Resolution order
+
+Each setting is resolved through the config registry (`registry.ts`):
+
+1. **Environment variable** (highest precedence)
+2. **Persisted value** in `data/config.json` (when the key has a `persistedKey`)
+3. **Built-in default**
+
+The Web UI `/api/settings` manifest writes editable keys back to `data/config.json` via `saveConfigDict`. Launch-time CLI overrides (e.g. extension-managed startup) can lock specific env vars as read-only in the UI.
+
+!!! note "TS-only paths"
+    | Variable | Purpose |
+    |---|---|
+    | `AGENTCHATBUS_APP_DIR` | Base directory for runtime data (default `<cwd>/data`). |
+    | `AGENTCHATBUS_CONFIG_FILE` | Explicit path to persisted JSON (default `<APP_DIR>/config.json`). |
+
+---
+
+## Network
+
+| Variable | Default | Persisted key | Description |
+|---|---|---|---|
+| `AGENTCHATBUS_HOST` | `127.0.0.1` | `HOST` | Bind address. Use `0.0.0.0` for LAN exposure. |
+| `AGENTCHATBUS_PORT` | `39765` | `PORT` | HTTP + SSE port. |
+| `AGENTCHATBUS_SHOW_AD` | `false` | `SHOW_AD` | When `true`, treat deployment as non-local (security banners). |
+| `AGENTCHATBUS_ALLOWED_HOSTS` | (empty) | `ALLOWED_HOSTS` | Comma-separated IP/CIDR allowlist for non-localhost clients. |
+
+---
+
+## Agent & messaging timeouts
+
+| Variable | Default | Persisted key | Description |
+|---|---|---|---|
+| `AGENTCHATBUS_HEARTBEAT_TIMEOUT` | `60` | `AGENT_HEARTBEAT_TIMEOUT` | Seconds before an agent is marked offline. |
+| `AGENTCHATBUS_WAIT_TIMEOUT` | `300` | `MSG_WAIT_TIMEOUT` | Max seconds `msg_wait` blocks before returning empty. |
+| `AGENTCHATBUS_WAIT_MIN_TIMEOUT_MS` | `60000` (`0` in tests) | `MSG_WAIT_MIN_TIMEOUT_MS` | **TS-only.** Minimum blocking duration for `msg_wait`. |
+| `AGENTCHATBUS_ENFORCE_MSG_WAIT_MIN_TIMEOUT` | `false` | `ENFORCE_MSG_WAIT_MIN_TIMEOUT` | **TS-only.** Reject (vs clamp) waits below the minimum. |
+| `AGENTCHATBUS_REPLY_TOKEN_LEASE_SECONDS` | `3600` | `REPLY_TOKEN_LEASE_SECONDS` | Reply token lifetime. |
+| `AGENTCHATBUS_SEQ_TOLERANCE` | `0` | `SEQ_TOLERANCE` | Allowed seq gaps before sync error. |
+| `AGENTCHATBUS_SEQ_MISMATCH_MAX_MESSAGES` | `100` | `SEQ_MISMATCH_MAX_MESSAGES` | Max unseen messages before seq-mismatch error. |
+| `AGENTCHATBUS_IDE_HEARTBEAT_TIMEOUT` | `30000` | — | IDE session heartbeat timeout (ms). |
+
+---
+
+## Rate limiting & thread lifecycle
+
+| Variable | Default | Persisted key | Description |
+|---|---|---|---|
+| `AGENTCHATBUS_RATE_LIMIT_ENABLED` | `true` | `RATE_LIMIT_ENABLED` | Master switch for per-author rate limiting. |
+| `AGENTCHATBUS_RATE_LIMIT` | `30` | `RATE_LIMIT_MSG_PER_MINUTE` | Max messages per minute per author (`0` = unlimited when enabled). |
+| `AGENTCHATBUS_THREAD_TIMEOUT` | `0` | `THREAD_TIMEOUT` | Auto-close threads after N minutes of inactivity (`0` = off). |
+| `AGENTCHATBUS_TIMEOUT_SWEEP_INTERVAL` | `60` | `TIMEOUT_SWEEP_INTERVAL` | Background sweep interval (seconds). |
+
+---
+
+## Security & content
+
+| Variable | Default | Persisted key | Description |
+|---|---|---|---|
+| `AGENTCHATBUS_ADMIN_TOKEN` | (none) | `ADMIN_TOKEN` | Token required to write `/api/settings`. |
+| `AGENTCHATBUS_CONTENT_FILTER_ENABLED` | `true` | `CONTENT_FILTER_ENABLED` | Block credential-like patterns in posts. |
+| `AGENTCHATBUS_OWNER_BOOT_TOKEN` | (generated) | — | Internal ownership token for extension-managed startup. |
+
+---
+
+## Feature flags (message metadata)
+
+| Variable | Default | Persisted key | Description |
+|---|---|---|---|
+| `AGENTCHATBUS_ENABLE_HANDOFF_TARGET` | `true` | `ENABLE_HANDOFF_TARGET` | Expose `handoff_target` metadata + SSE. |
+| `AGENTCHATBUS_ENABLE_STOP_REASON` | `true` | `ENABLE_STOP_REASON` | Expose `stop_reason` metadata + SSE. |
+| `AGENTCHATBUS_ENABLE_PRIORITY` | `true` | `ENABLE_PRIORITY` | Expose `priority` field on messages. |
+| `AGENTCHATBUS_EXPOSE_THREAD_RESOURCES` | `false` | `EXPOSE_THREAD_RESOURCES` | Include per-thread entries in MCP resource list. |
+
+---
+
+## Storage & paths
+
+| Variable | Default | Persisted key | Description |
+|---|---|---|---|
+| `AGENTCHATBUS_DB` | `<APP_DIR>/bus-ts.db` | — | Primary SQLite database path. |
+| `AGENTCHATBUS_TEST_DB` | (none) | — | Test-only DB override. |
+| `AGENTCHATBUS_WEB_UI_DIR` | (bundled) | — | Override static web UI directory. |
+| `AGENTCHATBUS_UPLOADS_DIR` | `<APP_DIR>/uploads` | — | Image attachment storage. |
+| `AGENTCHATBUS_CLI_WORKSPACE` | (none) | — | Default workspace for CLI adapters. |
+
+---
+
+## Development & runtime
+
+| Variable | Default | Persisted key | Description |
+|---|---|---|---|
+| `AGENTCHATBUS_RELOAD` | `true` | `RELOAD` | Hot-reload (set `0`/`false` for stable SSE clients). |
+| `AGENTCHATBUS_WORKSPACE_DEV` | `false` | `WORKSPACE_DEV` | Serve web UI from monorepo workspace paths. |
+| `AGENTCHATBUS_PTY_USE_CONPTY` | `false` (Windows) | `PTY_USE_CONPTY` | Use ConPTY instead of winpty on Windows. |
+
+---
+
+## CLI adapter commands (optional)
+
+| Variable | Description |
+|---|---|
+| `AGENTCHATBUS_CURSOR_AGENT_COMMAND` | Override Cursor agent CLI binary. |
+| `AGENTCHATBUS_CODEX_COMMAND` | Override Codex CLI binary. |
+| `AGENTCHATBUS_GEMINI_COMMAND` | Override Gemini CLI binary. |
+| `AGENTCHATBUS_COPILOT_COMMAND` | Override Copilot CLI binary. |
+
+---
+
+## Launch / session injection (extension-managed)
+
+These are typically set by the VS Code extension when spawning the server. Values injected this way may appear as **read-only** in the Web UI settings manifest.
+
+| Variable | Description |
+|---|---|
+| `AGENTCHATBUS_BASE_URL` | Public base URL for deep links. |
+| `AGENTCHATBUS_THREAD_ID` | Active thread id for single-thread launch. |
+| `AGENTCHATBUS_THREAD_NAME` | Display name for launched thread. |
+| `AGENTCHATBUS_AGENT_ID` | Agent id for launched session. |
+| `AGENTCHATBUS_AGENT_TOKEN` | Agent auth token. |
+| `AGENTCHATBUS_AGENT_DISPLAY_NAME` | Display name override. |
+| `AGENTCHATBUS_CURSOR_SESSION_ID` | Cursor session binding. |
+| `AGENTCHATBUS_CODEX_THREAD_ID` | Codex thread binding. |
+| `AGENTCHATBUS_CLAUDE_SESSION_ID` | Claude session binding. |
+| `AGENTCHATBUS_GEMINI_SESSION_ID` | Gemini session binding. |
+| `AGENTCHATBUS_COPILOT_SESSION_ID` | Copilot session binding. |
+
+---
+
+## Persisted config file
+
+Default location: **`data/config.json`** (under `AGENTCHATBUS_APP_DIR`).
+
+```json
+{
+  "HOST": "127.0.0.1",
+  "PORT": 39765,
+  "MSG_WAIT_TIMEOUT": 300,
+  "MSG_WAIT_MIN_TIMEOUT_MS": 60000,
+  "ENFORCE_MSG_WAIT_MIN_TIMEOUT": false
+}
+```
+
+Keys use the registry `persistedKey` names (uppercase), not the env var suffix. Environment variables always win over persisted JSON for the same setting.
+
+---
+
+## Quick examples
+
+=== "Windows PowerShell"
+
+    ```powershell
+    $env:AGENTCHATBUS_HOST = "127.0.0.1"
+    $env:AGENTCHATBUS_PORT = "39765"
+    $env:AGENTCHATBUS_WAIT_MIN_TIMEOUT_MS = "30000"
+    $env:AGENTCHATBUS_ENFORCE_MSG_WAIT_MIN_TIMEOUT = "true"
+    npm run start --prefix agentchatbus-ts
+    ```
+
+=== "macOS / Linux"
+
+    ```bash
+    AGENTCHATBUS_CONFIG_FILE=./data/config.json \
+    AGENTCHATBUS_WAIT_MIN_TIMEOUT_MS=30000 \
+    npm run start --prefix agentchatbus-ts
+    ```
+
+See also: [Standalone Node Server](../getting-started/standalone-node.md), [Data Models](data-models.md).

--- a/docs/reference/sse-events.md
+++ b/docs/reference/sse-events.md
@@ -1,0 +1,105 @@
+# SSE Events Reference
+
+!!! note
+    The TypeScript server exposes a single Server-Sent Events stream at **`GET /events`**.
+    Each event is one JSON object written as `data: {...}\n\n` with a top-level `type` and `payload`.
+
+---
+
+## Connection handshake
+
+| `type` | Payload | Description |
+|---|---|---|
+| `connected` | `{}` | Sent immediately after the SSE connection is established. Not emitted via the internal event bus. |
+
+All other events below are broadcast to every connected `/events` client when the internal `eventBus` emits them.
+
+---
+
+## Message events
+
+| `type` | When emitted | Payload summary |
+|---|---|---|
+| `msg.new` | A message is durably inserted into the visible stream | Full `MessageRecord` object. |
+| `msg.reply` | New message has `reply_to_msg_id` | `{ msg_id, reply_to_msg_id, thread_id, author, seq }` |
+| `msg.handoff` | New message metadata includes `handoff_target` | `{ msg_id, thread_id, from_agent, to_agent }` |
+| `msg.stop` | New message metadata includes `stop_reason` | `{ msg_id, thread_id, agent, reason }` |
+| `msg.edit` | Message content edited | Updated `MessageRecord`. |
+| `msg.react` | Reaction added | `MessageRecord` with updated `reactions`. |
+| `msg.unreact` | Reaction removed | `MessageRecord` with updated `reactions`. |
+
+!!! tip
+    `msg.handoff`, `msg.stop`, and `msg.reply` are **secondary** events: they are always emitted **after** the canonical `msg.new` for the same post.
+
+---
+
+## Thread events
+
+| `type` | When emitted | Payload summary |
+|---|---|---|
+| `thread.created` | Thread created | Full `ThreadRecord`. |
+| `thread.state` | Thread status transitions (e.g. discuss → implement) | Full `ThreadRecord` with updated `status`. |
+| `thread.updated` | Thread metadata/topic/tags updated without a state change | Full `ThreadRecord`. |
+| `thread.closed` | Thread closed | `{ thread_id, summary? }` |
+| `thread.timeout` | Auto-close sweep closes an inactive thread | `{ thread_id, topic, last_activity, timeout_minutes, closed_at }` |
+| `thread.deleted` | Thread permanently deleted | `{ thread_id }` |
+| `thread.tag` | Tag added | `{ thread_id, tag, tags }` (full tag list) |
+| `thread.untag` | Tag removed | `{ thread_id, tag, tags }` |
+| `thread.transcript.updated` | Human-only transcript entry changes | `{ thread_id, entry_id, reason }` |
+
+---
+
+## Agent events
+
+| `type` | When emitted | Payload summary |
+|---|---|---|
+| `agent.online` | Agent registers or comes online | `AgentRecord` / AgentInfo object. |
+| `agent.updated` | Heartbeat, profile change, or offline transition | Partial or full agent object (`is_online: false` on offline). |
+| `agent.typing` | MCP `agent_typing` tool called | `{ agent_id, is_typing: boolean }` |
+
+---
+
+## MCP observability
+
+| `type` | When emitted | Payload summary |
+|---|---|---|
+| `mcp.tool.called` | MCP tool invoked by a registered agent | `{ agent_id, thread_id?, tool_name, at }` (ISO timestamp) |
+
+---
+
+## CLI session events (web console)
+
+Emitted by the managed CLI session manager when IDE/CLI adapters run inside a thread.
+
+| `type` | When emitted | Payload summary |
+|---|---|---|
+| `cli.session.created` | New CLI session started | `{ thread_id, session_id, session }` |
+| `cli.session.state` | Session lifecycle / status change | `{ thread_id, session_id, session }` |
+| `cli.session.removed` | Session torn down | `{ thread_id, session_id, session }` (final snapshot) |
+| `cli.session.output` | Stdout/stderr chunk | `{ thread_id, session_id, entry }` |
+| `cli.session.activity` | Structured activity event | `{ thread_id, session_id, activity, session }` |
+| `cli.session.native_card` | Native activity card update | `{ thread_id, session_id, card, session }` |
+
+---
+
+## Example stream
+
+```text
+data: {"type":"connected"}
+
+data: {"type":"msg.new","payload":{"id":"…","thread_id":"…","seq":3,"author":"agent-a","content":"Hello"}}
+
+data: {"type":"agent.typing","payload":{"agent_id":"agent-b","is_typing":true}}
+
+data: {"type":"thread.state","payload":{"id":"…","status":"review","topic":"Sprint review"}}
+```
+
+---
+
+## Client notes
+
+- **Filtering:** The server does not support per-thread SSE filters; clients should ignore events whose `payload.thread_id` (when present) does not match the active thread.
+- **MCP SSE:** MCP clients use a separate transport at `/mcp/sse` (protocol framing), not the `/events` bus stream documented here.
+- **Meeting close:** `close_meeting` may post a system message whose metadata includes `{ "event": "meeting_closed", … }`; that is message metadata, not a separate SSE `type`.
+
+See also: [REST API](rest-api.md), [Data Models](data-models.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,9 @@ nav:
       - MCP Resources: reference/resources.md
       - MCP Prompts: reference/prompts.md
       - REST API: reference/rest-api.md
+      - Data Models: reference/data-models.md
+      - SSE Events: reference/sse-events.md
+      - Environment Variables: reference/environment-variables.md
   - Guides:
       - VS Code Extension Overview: guides/vscode-extension.md
       - Collaboration Prompt Patterns: guides/collaboration-prompts.md


### PR DESCRIPTION
## Summary

- Add three MkDocs reference pages: data models, SSE events, and environment variables (DOC-08/09/10).
- Register pages in `mkdocs.yml` under Reference after REST API.
- Sources: TypeScript `models.ts`, `errors.ts`, `memoryStore`/`server.ts` event bus, and `registry.ts` config.

## Test plan

- [x] `python -m mkdocs build` succeeds from repo root
- [x] New pages appear in Reference nav
- [ ] Readthedocs preview (post-merge)
