### PR TITLE
feat(mcp): workspace parity for bus_connect and thread_create (UL-8)

### DIFF
--- a/agentchatbus-ts/src/adapters/mcp/tools.ts
+++ b/agentchatbus-ts/src/adapters/mcp/tools.ts
@@ -1,5 +1,6 @@
 import { /* memoryStore replaced by getStore */ } from "../../core/services/memoryStore.js";
 import { AsyncLocalStorage } from "node:async_hooks";
+import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { eventBus } from "../../shared/eventBus.js";
@@ -33,6 +34,50 @@ export type ToolDefinition = {
   inputSchema: Record<string, unknown>;
 };
 
+const THREAD_CLI_WORKSPACE_METADATA_KEY = "cli_workspace";
+
+function normalizeWorkspaceCandidate(value: unknown): string | undefined {
+  const raw = String(value || "").trim();
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    return path.resolve(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+function isUsableWorkspaceCandidate(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  try {
+    return existsSync(value);
+  } catch {
+    return false;
+  }
+}
+
+function extractThreadCliWorkspace(thread: { metadata?: Record<string, unknown> } | undefined): string | undefined {
+  const candidate = thread?.metadata?.[THREAD_CLI_WORKSPACE_METADATA_KEY];
+  return typeof candidate === "string" && candidate.trim() ? candidate.trim() : undefined;
+}
+
+function resolveOptionalThreadWorkspace(workspaceArg: unknown):
+  | { ok: true; metadata?: Record<string, unknown>; workspace?: string }
+  | { ok: false; error: string } {
+  const requestedWorkspace = normalizeWorkspaceCandidate(workspaceArg);
+  const rawWorkspaceProvided = String(workspaceArg || "").trim().length > 0;
+  if (rawWorkspaceProvided && (!requestedWorkspace || !isUsableWorkspaceCandidate(requestedWorkspace))) {
+    return { ok: false, error: "workspace must be an existing directory" };
+  }
+  const metadata = requestedWorkspace
+    ? { [THREAD_CLI_WORKSPACE_METADATA_KEY]: requestedWorkspace }
+    : undefined;
+  return { ok: true, metadata, workspace: requestedWorkspace };
+}
+
 function emitObservedCliToolCall(agentId: string | undefined, toolName: string, threadId?: string): void {
   const normalizedAgentId = String(agentId || "").trim();
   if (!normalizedAgentId) {
@@ -62,6 +107,7 @@ const toolDefinitions: ToolDefinition[] = [
         agent_id: { type: "string", description: "Creator agent id. Required." },
         token: { type: "string", description: "Creator token for authentication. Required." },
         metadata: { type: "object", description: "Optional arbitrary key-value metadata." },
+        workspace: { type: "string", description: "Optional absolute or relative path to an existing directory used as the thread CLI workspace." },
         system_prompt: { type: "string", description: "Optional system prompt defining collaboration rules for this thread. Overrides template default." },
         template: { type: "string", description: "Template ID to apply defaults (system_prompt, metadata). Caller-provided values take precedence." }
       }
@@ -540,6 +586,7 @@ const toolDefinitions: ToolDefinition[] = [
             required: ["id", "name"]
           }
         },
+        workspace: { type: "string", description: "Optional absolute or relative path to an existing directory used as the thread CLI workspace. Only applied when creating a new thread (ignored when joining an existing one)." },
         system_prompt: { type: "string", description: "Optional system prompt for thread creation. Only applied when creating a new thread (ignored when joining an existing one). Overrides template default." },
         template: { type: "string", description: "Optional template ID for thread creation. Only applied when creating a new thread (ignored when joining an existing one)." }
       }
@@ -833,8 +880,13 @@ export async function callTool(name: string, args: Record<string, unknown>): Pro
 
       const templateId = typeof args.template === "string" ? args.template : undefined;
       const systemPrompt = typeof args.system_prompt === "string" ? args.system_prompt : undefined;
-      
+      const workspaceResolution = resolveOptionalThreadWorkspace(args.workspace);
+      if (!workspaceResolution.ok) {
+        return { error: workspaceResolution.error };
+      }
+
       const created = getStore().createThread(topic, systemPrompt, templateId, {
+        metadata: workspaceResolution.metadata,
         creatorAdminId: agentId,
         creatorAdminName: resolvePreferredAgentDisplayName(agent),
         applySystemPromptContentFilter: false
@@ -845,6 +897,7 @@ export async function callTool(name: string, args: Record<string, unknown>): Pro
         status: created.thread.status,
         system_prompt: created.thread.system_prompt,
         template_id: created.thread.template_id,
+        workspace: extractThreadCliWorkspace(created.thread),
         current_seq: created.sync.current_seq,
         reply_token: created.sync.reply_token,
         reply_window: created.sync.reply_window
@@ -1903,7 +1956,12 @@ export async function callTool(name: string, args: Record<string, unknown>): Pro
         }
         const templateId = typeof args.template === "string" ? args.template : undefined;
         const systemPrompt = typeof args.system_prompt === "string" ? args.system_prompt : undefined;
+        const workspaceResolution = resolveOptionalThreadWorkspace(args.workspace);
+        if (!workspaceResolution.ok) {
+          return [{ type: "text", text: JSON.stringify({ error: workspaceResolution.error }) }];
+        }
         const created = getStore().createThread(threadName, systemPrompt, templateId, {
+          metadata: workspaceResolution.metadata,
           creatorAdminId: agent.id,
           creatorAdminName: resolvePreferredAgentDisplayName(agent),
           applySystemPromptContentFilter: false
@@ -1955,6 +2013,7 @@ export async function callTool(name: string, args: Record<string, unknown>): Pro
           status: thread.status,
           created: threadCreated,
           ...(threadCreated && thread.system_prompt ? { system_prompt: thread.system_prompt } : {}),
+          ...(extractThreadCliWorkspace(thread) ? { workspace: extractThreadCliWorkspace(thread) } : {}),
           ...(adminId ? { administrator: { agent_id: adminId, name: adminName } } : {})
         },
         messages: getStore().projectMessagesForAgent(messages).map(m => ({

--- a/agentchatbus-ts/tests/integration/httpServer.test.ts
+++ b/agentchatbus-ts/tests/integration/httpServer.test.ts
@@ -1,4 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createHttpServer, getMemoryStore, memoryStoreInstance } from "../../src/transports/http/server.js";
 
 describe("HTTP compatibility shell", () => {
@@ -975,6 +978,114 @@ describe("HTTP compatibility shell", () => {
     expect(streamResponse.headers.get("content-type")).toContain("text/event-stream");
     await streamResponse.body?.cancel();
     await server.close();
+  });
+
+  it("MCP thread_create stores optional workspace on new threads", async () => {
+    const server = createHttpServer();
+    const workspaceDir = await mkdtemp(join(tmpdir(), "acb-mcp-workspace-"));
+
+    try {
+      const agent = (await server.inject({
+        method: "POST",
+        url: "/api/agents/register",
+        payload: { ide: "VSCode", model: "workspace-thread-create" }
+      })).json();
+
+      const createResponse = await server.inject({
+        method: "POST",
+        url: "/mcp/messages/",
+        payload: {
+          method: "tools/call",
+          params: {
+            name: "thread_create",
+            arguments: {
+              topic: "mcp-workspace-thread",
+              agent_id: agent.agent_id,
+              token: agent.token,
+              workspace: workspaceDir
+            }
+          }
+        }
+      });
+
+      expect(createResponse.statusCode).toBe(200);
+      const created = createResponse.json().result;
+      expect(created.workspace).toBe(workspaceDir);
+      expect(created.thread_id).toBeTruthy();
+
+      const thread = getMemoryStore().getThread(created.thread_id);
+      expect(thread?.metadata?.cli_workspace).toBe(workspaceDir);
+    } finally {
+      await rm(workspaceDir, { recursive: true, force: true });
+      await server.close();
+    }
+  });
+
+  it("MCP thread_create rejects invalid workspace paths", async () => {
+    const server = createHttpServer();
+    const agent = (await server.inject({
+      method: "POST",
+      url: "/api/agents/register",
+      payload: { ide: "VSCode", model: "workspace-thread-create-invalid" }
+    })).json();
+
+    const createResponse = await server.inject({
+      method: "POST",
+      url: "/mcp/messages/",
+      payload: {
+        method: "tools/call",
+        params: {
+          name: "thread_create",
+          arguments: {
+            topic: "mcp-invalid-workspace-thread",
+            agent_id: agent.agent_id,
+            token: agent.token,
+            workspace: join(tmpdir(), "acb-missing-workspace-dir")
+          }
+        }
+      }
+    });
+
+    expect(createResponse.statusCode).toBe(200);
+    const created = createResponse.json().result;
+    expect(created.error).toBe("workspace must be an existing directory");
+
+    await server.close();
+  });
+
+  it("MCP bus_connect stores optional workspace when creating a thread", async () => {
+    const server = createHttpServer();
+    const workspaceDir = await mkdtemp(join(tmpdir(), "acb-mcp-bus-connect-"));
+
+    try {
+      const connectResponse = await server.inject({
+        method: "POST",
+        url: "/mcp/messages/",
+        payload: {
+          method: "tools/call",
+          params: {
+            name: "bus_connect",
+            arguments: {
+              thread_name: "mcp-bus-connect-workspace",
+              ide: "VSCode",
+              model: "GPT-5.4",
+              workspace: workspaceDir
+            }
+          }
+        }
+      });
+
+      expect(connectResponse.statusCode).toBe(200);
+      const connected = JSON.parse(connectResponse.json().result[0].text);
+      expect(connected.thread.created).toBe(true);
+      expect(connected.thread.workspace).toBe(workspaceDir);
+
+      const thread = getMemoryStore().getThread(connected.thread.thread_id);
+      expect(thread?.metadata?.cli_workspace).toBe(workspaceDir);
+    } finally {
+      await rm(workspaceDir, { recursive: true, force: true });
+      await server.close();
+    }
   });
 
   it("serves the deprecated SSE fallback transport on /sse and /messages", async () => {

--- a/deprecated_src/python_standalone/pyproject.toml
+++ b/deprecated_src/python_standalone/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "mcp[cli]>=1.3.0",
+  "mcp[cli]>=1.3.0,<2.0.0",
   "fastapi>=0.115.0",
   "uvicorn[standard]>=0.30.0",
   "aiosqlite>=0.20.0",


### PR DESCRIPTION
## Summary

- Add optional `workspace` string parameter to MCP `thread_create` and `bus_connect` tool schemas.
- Validate workspace paths with the same rules as REST (`workspace must be an existing directory`) and persist as `cli_workspace` thread metadata via `MemoryStore.createThread`.
- Return `workspace` in MCP responses when set; `bus_connect` only applies workspace on new thread creation (ignored when joining an existing thread).

Unblocks **UL-8** / **UP-39** MCP workspace parity for RHUB orchestrator adoption.

## Test plan

- [x] `npx vitest run tests/integration/httpServer.test.ts` (31/31 passed)
- [x] MCP `thread_create` stores workspace on new threads
- [x] MCP `thread_create` rejects invalid workspace paths
- [x] MCP `bus_connect` stores workspace when creating a thread

## Notes

- Kanban #278 remains open until post-merge adoption in RHUB orchestrator (out of scope for this PR).
