### PR TITLE
chore(gitignore): ignore deprecated uploads and local VSIX artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,10 @@ pr-body-*.md
 
 # uploaded files
 src/static/uploads
+deprecated_src/python_standalone/agentchatbus/static/uploads/
+
+# VSIX build artifacts (install from GitHub release)
+vscode-agentchatbus/*.vsix
 
 # MkDocs build output
 site/


### PR DESCRIPTION
## Summary

- Ignore `deprecated_src/python_standalone/agentchatbus/static/uploads/` (runtime upload artifacts from deprecated Python standalone tree).
- Ignore `vscode-agentchatbus/*.vsix` (local extension build output; install from GitHub release instead).

## Why

Housekeeping after 0.2.31 release: test uploads and packaged VSIX files were showing as untracked noise on a clean `main` worktree. `src/static/uploads` was already ignored; this extends the same rule to the deprecated path and VSIX artifacts.

## Test plan

- [x] `git status` on `main` after local VSIX build / upload test shows no untracked clutter in those paths
